### PR TITLE
Fix completionSignal guarantee to prevent deadlocks

### DIFF
--- a/src/main/scala/bengal/stm/runtime/TxnRuntimeContext.scala
+++ b/src/main/scala/bengal/stm/runtime/TxnRuntimeContext.scala
@@ -328,7 +328,7 @@ private[stm] trait TxnRuntimeContext[F[_]] {
       for {
         _ <- ex.registerRunning(this)
         _ <- Async[F].uncancelable { poll =>
-               for {
+               (for {
                  result <- poll(commit)
                  _      <- ex.registerCompletion(this)
                  _ <- result match {
@@ -352,7 +352,10 @@ private[stm] trait TxnRuntimeContext[F[_]] {
                             .complete(Left[Throwable, V](err))
                             .void
                       }
-               } yield ()
+               } yield ()).handleErrorWith { unexpectedErr =>
+                 ex.registerCompletion(this).attempt >>
+                 completionSignal.complete(Left[Throwable, V](unexpectedErr)).void
+               }
              }
       } yield ()
   }
@@ -401,7 +404,12 @@ private[stm] trait TxnRuntimeContext[F[_]] {
               scheduler        = scheduler
             )
           )
-        _          <- scheduler.submitTxn(analysedTxn).start
+        _ <- (scheduler
+               .submitTxn(analysedTxn)
+               .handleErrorWith { err =>
+                 completionSignal.complete(Left[Throwable, V](err)).void
+               })
+               .start
         completion <- completionSignal.get
         result <- completion match {
                     case Right(res) => Async[F].pure(res)

--- a/src/test/scala/runtime/StmRuntimeSpec.scala
+++ b/src/test/scala/runtime/StmRuntimeSpec.scala
@@ -18,6 +18,7 @@ package ai.entrolution
 package runtime
 
 import scala.collection.immutable.Queue
+import scala.concurrent.duration._
 
 import cats.effect.IO
 import cats.effect.testing.scalatest.AsyncIOSpec
@@ -128,6 +129,20 @@ class StmRuntimeSpec extends AsyncFreeSpec with AsyncIOSpec with Matchers {
           } yield result
         }
         .asserting(_ shouldBe (27, Queue(18, 28)))
+    }
+
+    "transaction error completes rather than hanging" in {
+      STM
+        .runtime[IO]
+        .flatMap { implicit stm =>
+          STM[IO]
+            .abort(new RuntimeException("test error"))
+            .flatMap(_ => STM[IO].pure("unreachable"))
+            .commit
+            .attempt
+            .timeout(5.seconds)
+        }
+        .asserting(_.isLeft shouldBe true)
     }
   }
 }


### PR DESCRIPTION
## Summary
- **execute error guarantee**: unexpected exceptions inside `execute` now complete the `completionSignal` with `Left` and call `registerCompletion`, preventing callers from blocking indefinitely on `completionSignal.get`
- **Supervised fiber start**: errors from `submitTxn` (before `execute` is reached) are caught and complete the signal, providing a second layer of defense

## Test plan
- [x] New test: transaction error completes rather than hanging (abort + attempt + timeout)
- [x] All 143 tests pass on Scala 2.13 + Scala 3
- [x] Scalafix and scalafmt clean