### PR TITLE
chore: update GitHub username references to gvonnessi

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
-github: gvonness-apolitical
+github: gvonnessi
 patreon: Entrolution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - sbt-typelevel bumped from 0.8.4 to 0.8.5
 - Refactored `TxnLogContext`: extracted `getLogEntry` helper, unified duplicate entry/value write methods (−12% lines)
 - Adjusted CI stress test timeouts for reliability
-- Repository moved from `gvonness-apolitical` to `Entrolution` organisation
+- Repository moved from `gvonnessi` to `Entrolution` organisation
 - Updated CONTRIBUTING.md with cross-build guidance and CODE_OF_CONDUCT.md contact
 
 ## [0.11.0] - 2026-02-15

--- a/build.sbt
+++ b/build.sbt
@@ -27,7 +27,7 @@ ThisBuild / organizationName := "Greg von Nessi"
 ThisBuild / startYear        := Some(2023)
 ThisBuild / licenses         := Seq(License.Apache2)
 ThisBuild / developers ++= List(
-  tlGitHubDev("gvonness", "Greg von Nessi")
+  tlGitHubDev("gvonnessi", "Greg von Nessi")
 )
 
 ThisBuild / scalaVersion := DependencyVersions.scala2p13Version


### PR DESCRIPTION
Updates GitHub username references after the account rename `gvonness-apolitical` (and older `gvonness`) → `gvonnessi`.

Metadata only — no code/logic changes.

Files:
- `.github/FUNDING.yml`
- `CHANGELOG.md`
- `build.sbt`
