### PR TITLE
Add TLA+ formal specs: footprint relation and scheduler protocol (Phase 1)

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -1,0 +1,84 @@
+name: TLA+ Specs
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ['**', '!update/**', '!pr/**']
+    paths:
+      - 'specs/**'
+      - '.github/workflows/specs.yml'
+      - 'src/main/scala/bengal/stm/runtime/TxnRuntimeContext.scala'
+      - 'src/main/scala/bengal/stm/runtime/TxnLogContext.scala'
+      - 'src/main/scala/bengal/stm/model/runtime/IdFootprint.scala'
+      - 'src/main/scala/bengal/stm/model/runtime/TxnVarRuntimeId.scala'
+  pull_request:
+    paths:
+      - 'specs/**'
+      - '.github/workflows/specs.yml'
+      - 'src/main/scala/bengal/stm/runtime/TxnRuntimeContext.scala'
+      - 'src/main/scala/bengal/stm/runtime/TxnLogContext.scala'
+      - 'src/main/scala/bengal/stm/model/runtime/IdFootprint.scala'
+      - 'src/main/scala/bengal/stm/model/runtime/TxnVarRuntimeId.scala'
+
+concurrency:
+  group: ${{ github.workflow }} @ ${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  verify-anchors:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Verify SPEC anchors
+        run: ./specs/verify_anchors.sh
+
+  model-check:
+    runs-on: ubuntu-latest
+    needs: verify-anchors
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      # The v1.8.0 tag is a rolling pre-release (current nightly), so local
+      # and CI jars track each other but are not byte-stable over time — a
+      # pinned-red flip can therefore also mean TLC-version drift, not only
+      # a protocol change; check_expected.sh's failure text says to
+      # investigate before updating pins.
+      - name: Download TLA+ tools
+        run: |
+          curl -fsSL --retry 3 -o specs/tla2tools.jar \
+            https://github.com/tlaplus/tlaplus/releases/download/v1.8.0/tla2tools.jar
+          echo "TLC version:"
+          java -cp specs/tla2tools.jar tlc2.TLC -h 2>&1 | head -3
+
+      - name: Check Footprint lemmas (expected clean)
+        run: |
+          ./specs/check_expected.sh \
+            specs/common/FootprintLemmas.cfg \
+            specs/common/FootprintLemmas.tla \
+            NONE
+
+      - name: Check Scheduler (pinned H4 counterexample)
+        run: |
+          ./specs/check_expected.sh \
+            specs/scheduler/Scheduler.cfg \
+            specs/scheduler/Scheduler.tla \
+            NoDoubleExec
+
+      - name: Check Scheduler robustness (pinned, dispatch only)
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          ./specs/check_expected.sh \
+            specs/scheduler/SchedulerAborts.cfg \
+            specs/scheduler/Scheduler.tla \
+            CompletionAtMostOnce

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,11 @@ target
 /src/main/resources/dataDecrypted/
 scoverage-data/
 scoverage-report/
+
+# TLA+ tooling (specs/) — jar downloaded in CI, TLC run artifacts never committed
+specs/tla2tools.jar
+specs/**/*_TTrace_*
+specs/**/states/
+
+# TLC drops states/ in the working directory
+/states/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,18 @@ Key conventions:
 - Tests are located in `src/test/scala`
 - Run tests with `sbt test`
 
+## Formal Specifications
+
+The scheduler and commit protocols carry TLA+ specifications under `specs/`
+(see `specs/README.md`). PRs touching `TxnRuntimeContext.scala`,
+`TxnLogContext.scala`, `IdFootprint.scala`, or `TxnVarRuntimeId.scala` must
+update the specs to match — or state in the PR description why no protocol
+behaviour changed. CI enforces two things on these paths: `// SPEC:` anchors
+listed in `specs/README.md` must exist, and pinned model-checking
+expectations must reproduce (a pinned counterexample that stops reproducing
+means the protocol changed — update the spec, the verdict table, and
+`docs/plans/formal-specs.md` together).
+
 ## License
 
 By contributing to Bengal STM, you agree that your contributions will be licensed under the Apache License 2.0.

--- a/docs/plans/formal-specs.md
+++ b/docs/plans/formal-specs.md
@@ -1,0 +1,431 @@
+# Formal Specification Plan — Scheduler & Commit Protocols
+
+**Status:** Phases 0–1 executed (2026-07-11) on branch `formal-specs-phase-1` —
+`specs/README.md` is now the verdict source of truth. **H4 CONFIRMED
+organically** (all six Spec B safety invariants violated, minimal
+counterexample pinned in CI at TLC search depth ~50; see the verdict table). H5's
+relation-level premise confirmed by `FootprintLemmas.tla`
+(`DocumentsReadGapH5`); behavioural check remains Phase 3. The
+serializability oracle test was deferred to a sibling PR (allowed by §8).
+Phase 2 (retry/park/wake + liveness, H1) and Phase 3 (Spec A, H2/H3/H5) are
+next. Plan below retained as written (critique-ratcheted: self-review +
+independent agent review applied). **Invariant naming note:** implementation
+tightened some planned property names — `TallyIsUpstreamCount` shipped as
+the weaker-but-sufficient `TallyNonNegative`, `CompletionExactlyOnce`'s
+safety half as `CompletionAtMostOnce`, and `StatusWellFormed` as
+`NoDoubleExec` + `NoExecOnCompleted`; `NoDroppedSpawn` was added as a
+model-capacity detector. `specs/README.md` uses the shipped names. Line
+references in the plan body below predate the `// SPEC:` anchor insertions
+(off by up to 18 lines in `TxnRuntimeContext.scala` / `IdFootprint.scala`);
+the specs and `specs/README.md` cite symbols and are authoritative.
+**Tooling:** TLA+ / TLC (echidna house pattern)
+**Scope:** `TxnRuntimeContext.scala`, `TxnLogContext.scala` (commit path), `IdFootprint.scala`, `TxnVarRuntimeId.scala`
+
+---
+
+## 1. Objective
+
+Formally specify bengal-stm's two concurrency-critical protocols in TLA+, model-check
+them with TLC, and wire mechanical spec↔code alignment so the specs stay honest as the
+code evolves. The recent bug history (#50 retry-in-handleErrorWith, #51 TxnVarMap
+new-key concurrency, #52 completionSignal deadlock) is concentrated exactly in this
+protocol layer.
+
+**These specs will verify (protocol-level correctness):**
+
+- The transaction scheduler: dependency-graph construction, dependency tallies,
+  execution statuses, unsubscribe cascades, the retry map, and park/wake — including
+  the error-recovery paths.
+- The commit protocol: sorted lock acquisition, dirty-check validation, version
+  publication.
+- The footprint compatibility relation itself (shared module, §3).
+- The interface between scheduler and commit (Contract C, §3).
+
+**They will not verify:**
+
+- The free-monad compiler / static-analysis walker (`TxnCompilerContext`) — though
+  H5 requires *reading* its output conventions once (§6).
+- `TxnLog` map-merge bookkeeping (`getVarMap`/`extractMap` semantics).
+- Value-level semantics (vars are abstracted to version counters).
+- Cancellation (all protocol regions of interest sit inside `uncancelable`).
+- `TxnVarMap.internalStructureLock` — a second locking layer acquired during commit
+  publication *underneath* the modelled `commitLock`s (`TxnVarMap.scala:86`). It is a
+  leaf lock (never held while acquiring a commit lock), so it sits safely below
+  Spec A's atomic-publish abstraction; recorded here because it is the only commit-path
+  lock the specs do not represent.
+- Type-erasure hazards (Scala-level; property-test territory).
+- Runtime-ID hash collisions (§10, treated as an explicit `ASSUME`).
+
+## 2. Tooling & Layout (echidna house pattern)
+
+Mirror `../echidna` exactly:
+
+```
+specs/
+  README.md               # scope, run commands, cross-reference tables, variable
+                          # mapping, parameter sweeps, design decisions, verdicts
+  verify_anchors.sh       # ported from echidna; parses README tables, greps Scala
+  common/
+    Footprint.tla         # IdFootprint + isCompatibleWith, exactly once (§3)
+    Footprint.cfg         # footprint-only lemma checks (symmetry, validation
+                          # idempotence, parent-rule cases)
+  scheduler/
+    Scheduler.tla         # Spec B (safety)
+    Scheduler.cfg         # safety config (symmetry, larger bounds)
+    SchedulerLiveness.cfg # liveness config (no symmetry — TLC restriction; minimal bounds)
+  commit/
+    CommitProtocol.tla    # Spec A
+    CommitProtocol.cfg          # accurate-footprint mode (two maps — see H2)
+    CommitProtocolFallback.cfg  # under-approximated-footprint mode (H3)
+.github/workflows/specs.yml     # verify-anchors + model-check jobs (ubuntu-latest,
+                                # temurin 21, tla2tools v1.8.0, -workers auto)
+```
+
+Conventions carried over: raw TLA+ (no PlusCal), heavily-commented module headers with
+phase breakdown and a "Scala correspondence" note per action, `.cfg` per checkable
+concern, shared operators in a common module (echidna's `BinomialBeta.tla` precedent),
+`tla2tools.jar` gitignored and downloaded in CI, `*_TTrace_*` TLC trace dumps
+gitignored (echidna committed one by accident — avoid repeating).
+
+CI runs on GitHub-hosted `ubuntu-latest` (as echidna does), not Blacksmith — keeps the
+2-vcpu Blacksmith minutes for sbt. Path triggers: `specs/**` plus the four in-scope
+source files. **CI budget is arithmetic, not aspiration:** with ~6 configs at a
+single-digit-minute target each, the model-check job either matrixes per-config or
+raises its timeout to ~30 min; config sizes are locked only after the Phase 1
+state-count spike (§8) measures real states/minute on the CI runner class.
+Deeper bounds are documented as manual sweeps in `specs/README.md`.
+
+## 3. Architecture: Two Specs, a Shared Relation, and an Interface Contract
+
+A single monolithic model (scheduler + locks + dirty checks + retry map) would be
+unwieldy and slow to check. The split is sound because the two protocols meet at one
+narrow interface:
+
+> **Contract C:** no two transactions whose *declared* footprints are incompatible
+> (`IdFootprint.isCompatibleWith = false`) are ever concurrently inside their
+> execute/commit window.
+
+- **`common/Footprint.tla`** encodes `IdFootprint` and `isCompatibleWith` **exactly**
+  — raw-ID intersection plus the parent rule (`IdFootprint.scala:52-58`), and
+  `getValidated` (`IdFootprint.scala:26-34`) — once, EXTENDed by both specs. Scenario
+  configs must never hand-pick "compatible/incompatible" pairs; compatibility is always
+  computed by this module (H2's original misdiagnosis in an earlier draft of this plan
+  — see §6 — is exactly the error this rule prevents). The module gets its own tiny
+  lemma config: symmetry of `isCompatibleWith`, idempotence of `getValidated`,
+  and the parent-rule case table.
+- **Spec B** (scheduler) *checks* Contract C, plus liveness of the retry machinery.
+- **Spec A** (commit) *assumes* Contract C and checks strict serializability and
+  deadlock freedom of the lock/validate/publish sequence.
+
+**Why this decomposition is load-bearing — the central design fact:** read-only log
+entries are never validated at commit time (`TxnLogReadOnlyVarEntry.isDirty =
+pure(false)`, `lock = None` — `TxnLogContext.scala:70-74`) and commit locks cover only
+the write set. The commit protocol *alone* therefore does not give serializability;
+the scheduler's conflict avoidance is the only defence against stale reads and write
+skew. Consequently the accuracy of declared footprints is a safety precondition, and
+the static-analysis fallback to a partial or empty footprint
+(`TxnRuntimeContext.scala:382-387`) is a soundness boundary, not an optimisation
+detail (hypothesis H3) — and any gap in `isCompatibleWith` itself is a direct hole in
+the safety story (hypothesis H5).
+
+**Conditional validity of the assume-guarantee split.** Spec B is *expected to refute*
+Contract C on the shipped code (H4; H5 attacks it at the relation level). Until those
+verdicts resolve — fix landed or interleaving argued unreachable — Spec A's
+accurate-mode "holds" verdicts describe the **post-fix system**, not the shipped
+library. The same condition attaches to §3's refinement justification below. This is
+stated in the Phase 3 exit criteria and must be stated in `specs/README.md`'s verdict
+table rather than silently assumed.
+
+**Refinement obligation (documented, not machine-checked initially):** Spec B treats
+commit as one atomic version-bump action. Spec A justifies this coarsening: under
+Contract C with accurate footprints, conflicting commits are mutually excluded, so
+their internal steps cannot interleave observably. A machine-checked refinement
+mapping (B's atomic commit ⊑ A) is a stretch goal (§8).
+
+## 4. Spec A — `commit/CommitProtocol.tla`
+
+**Purpose:** verify the `withLock` + `isDirty` + `commit` sequence
+(`TxnLogContext.scala:997-1039`, `TxnRuntimeContext.scala:279-323`).
+
+**State (↔ code):**
+
+| TLA+ variable | Scala correspondence |
+|---|---|
+| `version[v]` | abstract commit counter per `TxnVar`/map entry/map structure (values abstracted away) |
+| `lockHolder[l]` | `commitLock: Semaphore[F]` per var and per map (structural); map-entry writes resolve to the entry's own lock or the structural lock per the fallback rule |
+| `txnPc[t]` | position in read → sort → acquire(k) → validate → publish/release |
+| `snapshot[t][v]` | `initial` captured in log entries during the read phase |
+| `readSet[t]`, `writeSet[t]` | the txn's *actual* access sets |
+| `declared[t]` | the txn's *declared* footprint (= actual, or an under-approximation, per mode) |
+| `lockSeq[t]` | lock IDs sorted by runtime-ID value (`TxnLogContext.scala:1029-1036`) |
+
+**Model design decisions:**
+
+- **Runtime IDs are arbitrary distinct naturals chosen adversarially in the config.**
+  Real IDs are UUID-hash-derived (`TxnStateEntity.scala:36-37`), so their order is
+  pseudorandom relative to creation order — every ordering class is reachable in some
+  program. Configs pin concrete orderings that exercise each class (for H2: entry IDs
+  of map 1 and map 2 interleaved in opposite orders).
+- **The map-lock fallback is modelled faithfully:** a new-key map entry contributes
+  the *map's* structural lock at the *entry's* position in the sorted sequence
+  (`TxnLogContext.scala:276-279`), while a map-structure write contributes the same
+  lock at the *structure's* position. Lock *identity* is state-dependent — the aliasing
+  at the heart of H2.
+- **Dirty check matches the code, not the textbook:** only write-set entries are
+  validated (`version[v] = snapshot[t][v]` for `v ∈ writeSet[t]`); read-only entries
+  contribute nothing. Do not "fix" this in the model — exposing its consequences is
+  the point.
+- **The retry branch is in scope but modelled as the code has it, which is weaker
+  than it looks:** the `TxnLogRetry` re-validation under lock
+  (`TxnRuntimeContext.scala:306-319`) delegates to `validLog.isDirty`
+  (`TxnLogContext.scala:1088-1089`), whose read-only entries are always clean and
+  lockless — for the typical read-then-retry transaction it acquires **no locks and
+  can never report dirty**. The model must reproduce this vacuity (park decisions
+  consult no versions); a model that "helpfully" re-validates before parking would
+  mask H1-adjacent traces. Pinned in the fidelity table (§5).
+- **Lock acquisition is one step per lock** (blocking); validate-and-publish happens
+  while holding exactly the write-set locks; dirty → release all, refine declared
+  footprint from actual, re-enter read phase (models `TxnResultLogDirty` →
+  `submitTxnForImmediateRetry`).
+- **Contract C as an action guard:** in accurate mode, a txn may enter its
+  execute window only if no txn with an incompatible declared footprint (computed by
+  `common/Footprint.tla`, never hand-assigned) is inside its own. In fallback mode the
+  guard uses the under-approximated declared footprints — TLC then explores the
+  concurrency the real scheduler would permit.
+
+**Properties:**
+
+| Property | Kind | Expected initial verdict |
+|---|---|---|
+| `NoWaitsForCycle` — no cycle in the waits-for graph over lock holders/waiters (explicit invariant, not TLC's built-in deadlock detection, which terminal all-done states would trip) | safety | **counterexample** at two-map config (H2) |
+| `CommitSnapshotValid` — at publish, every `v ∈ readSet` (structure reads included) still has its snapshot version | safety (strong form of strict serializability) | **counterexample** in accurate mode via phantom insert (H5); **counterexample** in fallback mode (H3, write skew) |
+| `PublishedExactlyOnce` — a txn's writes are published at most once per incarnation | safety | holds |
+| `EventualCommit` — every non-retry txn eventually publishes (weak fairness; see §9 fairness caveat) | liveness | holds in accurate mode, post-fix |
+
+If `CommitSnapshotValid` fails in accurate mode *other than* via the H5 mechanism,
+fall back to an explicit history-based serializability check (maintain committed
+history, assert a serial order exists) before declaring an anomaly — snapshot
+validity is sufficient but not necessary for serializability. Build that checker
+only if needed.
+
+**Config:** 2–3 txns, 2 plain vars + **2 maps** (structure + ≤2 entries each — two
+maps are required for H2's accurate-mode cycle; one map cannot produce two shared
+locks between footprint-compatible txns). Symmetry over txns in safety runs only.
+
+## 5. Spec B — `scheduler/Scheduler.tla`
+
+**Purpose:** verify the scheduler protocol of `TxnRuntimeContext.scala:53-361` —
+graph building, tallies, statuses, unsub cascades, retry map, park/wake, error
+recovery — at the granularity where the real races live.
+
+**State (↔ code):**
+
+| TLA+ variable | Scala correspondence |
+|---|---|
+| `active` | `activeTransactions: MutableMap[TxnId, AnalysedTxn[_]]` |
+| `status[t]` | `executionStatus: Ref[F, ExecutionStatus]` (+ `Completed` for bookkeeping) |
+| `tally[t]` | `dependencyTally: Ref[F, Int]` |
+| `unsubs[t]` | `unsubSpecs: MutableMap[TxnId, F[Unit]]` (set of downstream ids) — **shared across incarnations** (case-class `copy`, line 348) |
+| `hasDownstream[t]` | `hasDownstream: Ref[F, Boolean]` |
+| `completed[t]` | `completionSignal: Deferred` (completed-once flag) |
+| `declared[t, i]` | declared footprint **per incarnation** `i` — refined on the dirty path (`TxnRuntimeContext.scala:346-349`); Contract C is checked against the *current* incarnation's footprint |
+| `snapshot[t]` | versions of the txn's actual footprint captured at execute start — needed to force the dirty outcome truthfully (dirty iff a written var's version changed) rather than nondeterministically |
+| `retryMap` | `retryMap: MutableMap[IdFootprint, F[Unit]]` (footprint → set of parked ids; the code's `>>` chaining = fire-together, a set suffices) |
+| `graphSem`, `retrySem` | the two semaphores, as explicit holder variables |
+| `version[v]` | coarse var state; commit = one atomic bump of the write set (§3) |
+| `fiberPc[f]` | program counters for in-flight fibers (submit scans, triggerUnsub cascades, executes) |
+
+**Atomicity mapping (the fidelity crux).** The model's atomic step = one operation on
+one shared mutable object:
+
+- each `Ref` `get`/`set`/`update`/`getAndUpdate` — one step (atomic in CE);
+- each `TrieMap` read/insert/remove — one step;
+- check-then-act sequences (e.g. `unsubSpecs.contains` then `addOne`,
+  `TxnRuntimeContext.scala:241-254`) — two steps, interleavable;
+- semaphore-guarded regions are **not** atomic: they serialise against the same
+  semaphore only. Steps of `triggerUnsub` fibers (which run *outside* the graph
+  semaphore, `TxnRuntimeContext.scala:184`) interleave freely with in-region
+  subscribe steps;
+- `.start`ed fibers (`testAndLink` scans, `triggerUnsub`, spawned `execute`s,
+  `checkRetryQueue`) are separate model fibers; `joinWithNever` inside the region
+  pins their completion before semaphore release, as in the code;
+- **park decisions consult no versions** — the retry-path re-validation is vacuous
+  for read-only logs (§4); the model must not re-check freshness before parking.
+
+This mapping is recorded as a table in `specs/README.md`; every action comment in the
+spec cites the line range it models.
+
+**Finiteness engineering (required, not assumed).** Fiber-level interleaving at this
+granularity explodes fast, and TLC needs the model to be finite by construction:
+
+- No dynamically spawned model fibers: scan work, unsub cascades, and wake-ups are
+  encoded as **pending-work sets** drained one step at a time (equivalent
+  interleavings, bounded state), with a fixed small fiber pool only where genuine
+  concurrent identity matters (the `triggerUnsub`-vs-resubmit race needs two).
+- Explicit bounds as CONSTANTS with `CONSTRAINT` backstops: max incarnations per txn
+  (dirty/retry loops), max version per var, max simultaneous submissions.
+- Liveness caveat recorded in the spec header: `CONSTRAINT`-truncated behaviours can
+  mask liveness violations near the bound; liveness configs choose bounds where
+  the interesting cycle fits well inside the horizon.
+- **Phase 1 exit criterion includes a measured state-count spike** (states, distinct
+  states, minutes on a CI-class runner) before config sizes are locked (§8).
+
+**Behaviours modelled:** `submitTxn`, `submitTxnForImmediateRetry` (including its
+Running/Scheduled asymmetric subscribe, lines 106-133, and the shared
+`unsubSpecs`/`dependencyTally` refs across incarnations), `registerRunning`, `execute`
+outcome dispatch (success / retry / dirty / failure — dirty forced truthfully from
+`snapshot`), `registerCompletion` + `triggerUnsub`, `submitTxnForRetry` (park),
+`checkRetryQueue` (wake), `checkExecutionReadiness` and
+`unsubscribeUpstreamDependency` zero-tests, **and the error-recovery branches**: a
+nondeterministic step-failure action driving `execute`'s `handleErrorWith`
+(`TxnRuntimeContext.scala:355-358`) — which runs `registerCompletion` a **second**
+time and starts a second `triggerUnsub` over the shared `unsubs`, a double-unsub /
+negative-tally hazard (H4's failure family via the #52-fix path) — plus the submit
+wrapper's error completion (`TxnRuntimeContext.scala:407-411`). These paths are what
+make `CompletionExactlyOnce` a meaningful check; scoping them out would verify only
+the happy path of the very fix (#52) that motivated this work.
+
+**Properties:**
+
+| Property | Kind | Expected initial verdict |
+|---|---|---|
+| `TallyIsUpstreamCount` — `tally[t]` equals the number of live upstream edges pointing at `t` | safety (inductive-strength; catches tally corruption) | **counterexample** (H4) |
+| `ContractC` — no two Running txns have incompatible declared footprints (current incarnations; relation from `common/Footprint.tla`) | safety (the Spec A interface) | **counterexample** (H4 corollary) |
+| `StatusWellFormed` — per incarnation: NotScheduled → Scheduled → Running → Completed, no double-fire of `execute` | safety | to determine — no explicit guard exists in the code |
+| `CompletionExactlyOnce` — `completionSignal` completed exactly once per submitted txn, including error paths (the #52 class) | safety + liveness | safety: to determine (double-`registerCompletion` path); liveness follows H1 verdict |
+| `ParkedConsistency` — parked ⇒ not in `active`, tally = 0 | safety | holds |
+| `NoLostWakeup` — a parked txn flagged by a conflicting commit after its park point is eventually resubmitted (flag-based encoding) | liveness (weak fairness; §9 caveat) | **counterexample** (H1) |
+| `EventualCompletion` — every submitted txn (with a satisfiable retry predicate) eventually completes | liveness | follows H1 verdict |
+
+**Config:** 3 txns / 2 vars for safety (symmetry over vars), 2 txns / 1–2 vars for
+liveness. Footprints are constants per txn *base*, always run through
+`common/Footprint.tla` for compatibility; retry txns get a predicate that becomes
+true after a designated write.
+
+## 6. Hypothesis Regression List (model acceptance criteria)
+
+Five concrete suspected defects came out of the pre-planning code read and the plan
+critique. They double as **fidelity acceptance tests**: the finished specs must either
+reproduce each counterexample or return *no counterexample at the stated bounds
+plus a written mechanism argument* for why the interleaving is excluded (bounded TLC
+runs cannot prove unreachability — H2's own history below shows how a too-small
+config silently excludes a behaviour). A spec that can do neither is modelling a
+different algorithm and goes back for granularity rework before any green invariant
+is trusted. Each row must record why its config bounds suffice to exhibit the claimed
+behaviour.
+
+| # | Hypothesis | Spec / property | Code site | Expected |
+|---|---|---|---|---|
+| H1 | **Park/submit lost-wakeup window.** On `TxnResultRetry`, `registerCompletion` (removes txn from `active`) precedes the park into `retryMap`. A conflicting writer submitted in the gap sees the txn in neither structure (no graph edge, no wake), commits, and nothing ever wakes the parked txn — wakes fire only on submission. | B / `NoLostWakeup` | `TxnRuntimeContext.scala:330-359`, `61-95` | counterexample (2 txns, 1 var suffice: the window is a pure ordering race) |
+| H2 | **Lock-order inversion via the map-lock fallback — two maps.** New-key entries acquire the *map's* structural lock at the *entry's* hash-derived sort position. Two txns inserting fresh keys into maps M1 and M2 have pairwise-compatible footprints (disjoint entry IDs; nobody writes a structure ID), yet both hold `{M1.lock, M2.lock}` — and adversarial ID ordering acquires them in opposite orders. Circular wait under accurate footprints. *(A one-map variant with a shared plain var is footprint-incompatible and thus Contract-C-excluded — an earlier draft of this plan got that wrong, which is why compatibility is computed, never hand-assigned; the one-map variant remains reachable in fallback mode.)* | A / `NoWaitsForCycle` | `TxnLogContext.scala:276-279, 1029-1036`, `TxnVarMap.scala:83` | counterexample (requires the 2-map config; bounds note in row) |
+| H3 | **Write skew when declared footprints under-approximate.** Reads are never commit-validated and read locks don't exist, so two txns in the empty-footprint fallback (`r x, w y` vs `r y, w x`) both validate and both publish. The refinement path never triggers because neither log is dirty. | A / `CommitSnapshotValid` (fallback mode) | `TxnLogContext.scala:70-74`, `TxnRuntimeContext.scala:382-387` | counterexample in fallback mode |
+| H4 | **Incarnation confusion on dirty resubmit.** `this.copy(idFootprint = …)` shares `unsubSpecs` and `dependencyTally` refs with the previous incarnation, and `triggerUnsub` is a fire-and-forget fiber racing the resubmit's graph scan. A stale `unsubSpecs.contains` hit skips a needed subscription (tally under-count → premature execute, Contract C breach) and stale unsubs can drive the tally negative. The double-`registerCompletion` error path (§5) reaches the same failure family without a dirty retry. | B / `TallyIsUpstreamCount`, `ContractC`, `CompletionExactlyOnce` | `TxnRuntimeContext.scala:184, 238-254, 346-349, 355-358` | **CONFIRMED (2026-07-11)** — organic counterexample, variant mechanism: the resubmission's reversed edge lands on a txn whose execute fiber was already spawned (`registerRunning` re-checks nothing), and the previous incarnation's cascade drains the new incarnation's edge from the shared `unsubSpecs`, spawning a second execute → double commit, double completion, negative tally, Contract C breach. Pinned in CI (`NoDoubleExec`); full narrative in `specs/README.md` |
+| H5 | **Phantom write skew under fully accurate footprints.** The parent rule in `isCompatibleWith` checks each side's IDs only against the other side's *update* IDs (`IdFootprint.scala:52-58`) — a child-entry **write** is never tested against a parent-structure **read**. So "read whole map" (`readIds ∋ structureId`) vs "insert new key" (`updatedIds ∋ entryId(parent=structureId)`) is judged compatible; the structure RO entry is never validated and holds no lock (`TxnLogContext.scala:143-147`); two check-then-insert txns both see the key absent and both commit. Breaks serializability with *no* fallback involved — the relation itself has the hole. **Verification pre-step:** confirm what footprint the static-analysis walker emits for `getVarMap`/`getVarMapValue`/`setVarMapValue` before finalising the scenario (if the walker happens to over-approximate to a structure *write*, the hole closes for some idioms — check, don't assume). | A / `CommitSnapshotValid` (accurate mode); `common/Footprint.tla` lemma table documents the relation gap | `IdFootprint.scala:52-58`, `TxnLogContext.scala:143-147` | counterexample in accurate mode (pending the pre-step) |
+
+**Verdict handling:** each confirmed counterexample becomes a decision point, not an
+automatic fix: (a) fix the code (separate PR: fix + deterministic replay/stress test +
+TLC re-run flipping the expected verdict), or (b) accept and document as a known
+boundary in `specs/README.md` (plausible for H3 if the fallback is deemed acceptable
+risk — though a cheap sound fix exists: an under-approximation *flag* that makes the
+footprint incompatible-with-everything, trading throughput for soundness on the
+fallback path only; for H5 the likely fixes are extending the parent rule to cover
+parent-*reads* or validating structure reads at commit). Hypotheses that produce no
+counterexample get the bounded-verdict treatment described above, recorded in the
+spec header. **Once specs land, the verdict table in `specs/README.md` is the source
+of truth and this section becomes a pointer to it.**
+
+## 7. Spec↔Code Alignment Mechanism
+
+Echidna's three-layer pattern, adapted for Scala/CE:
+
+1. **Source anchors + cross-reference tables.** Every invariant in §4/§5 gets a
+   `// SPEC: <InvariantName>` comment at the Scala line that upholds it, a row in the
+   `specs/README.md` cross-reference tables, and `verify_anchors.sh` (direct port —
+   Scala's `//` comments make the grep identical, and the existing `src/` path regex
+   already matches `src/main/scala/…`) fails CI if an anchor disappears. Anchors are
+   added **incrementally in each spec PR**, not retrofitted at the end. For
+   expected-red invariants, anchor placement is ill-defined until the fix lands —
+   those rows anchor the *mechanism site* (e.g. the subscribe dedup check for
+   `TallyIsUpstreamCount`) and move to the fix site in the Phase 5 PR. Same known
+   limitation as echidna: anchors moved to a wrong line *within* the declared file
+   remain a reviewer responsibility.
+
+2. **Semantic property tests** (`src/test/scala/spec/`, package `ai.entrolution.spec`
+   — test packages must stay outside `stm` to avoid `private[stm]` member shadowing):
+   - **Serializability oracle test (pulled forward to Phase 1 — it is
+     TLA-independent and exercises the real code):** a deliberately naive reference
+     STM (one global lock, sequential commits) as oracle; ScalaCheck generates small
+     concurrent workloads (2–4 txns over 2–3 vars/map keys, including retry, map
+     new-key inserts, and whole-map reads — the H5 idiom); the real STM's observable
+     outcome must be reachable by some serial order in the oracle. This generalises
+     the conserved-quantity checks in the existing `StmStressSpec` (which validates
+     specific invariants like transfer totals) to arbitrary generated workloads, and
+     runs in the normal 2.13/3 test matrix.
+   - **Counterexample replay tests:** each confirmed TLC trace is hand-translated
+     into a test. Honest caveat: `TestControl` gives a deterministic scheduler, not
+     arbitrary interleaving control — where a trace needs a precise interleaving,
+     replay tests use `Deferred`-based sync points or a bounded stress loop asserting
+     the fixed invariant. Named after the TLA+ action sequence they replay.
+   - **(Stretch) sync-point seam:** a no-op `private[stm] def tracePoint(label): F[Unit]`
+     at the ~8 protocol edges (post-completion/pre-park, post-scan/pre-subscribe, …),
+     overridable in tests to enforce exact interleavings — upgrades replay tests from
+     stress loops to deterministic reproductions, and opens the door to full trace
+     validation later. Zero production cost; only added if stress-loop replay proves
+     flaky.
+
+3. **CI (`specs.yml`)** mirroring echidna's: `verify-anchors` job (2-min timeout,
+   Java-free) gating a `model-check` job (temurin 21, TLC 1.8.0, `-workers auto`),
+   per-config matrix or ~30-min timeout per §2, running every `.cfg`. Plus a
+   CONTRIBUTING.md note: PRs touching the four in-scope files must update the specs
+   or state why no protocol behaviour changed.
+
+## 8. Phasing
+
+Each phase is one PR (house `/commit` + `/pr` flow). Estimates are focussed working
+days, not calendar days.
+
+| Phase | Content | Est. | Exit criterion |
+|---|---|---|---|
+| 0 | Scaffolding: `specs/` tree, README skeleton, `verify_anchors.sh` port, `specs.yml`, gitignore entries | 0.5d | CI green with empty-but-wired pipeline (may fold into phase 1's PR) |
+| 1 | `common/Footprint.tla` + lemma config; Spec B core safety: submit/graph/tally/unsub/complete + error-recovery branches (no retry map); `TallyIsUpstreamCount`, `ContractC`, `StatusWellFormed`, `CompletionExactlyOnce`(safety), `ParkedConsistency`; **H4 verdict**; **state-count spike** to size configs; **serializability oracle test** (TLA-independent, can land as a sibling PR) | 3–4d | TLC runs green-or-expected-red on measured, locked configs; H4 trace or bounded-verdict note in hand; oracle test in the matrix |
+| 2 | Spec B retry + liveness: retryMap, park/wake, `hasDownstream` branch, fairness; `NoLostWakeup`, `EventualCompletion`; **H1 verdict** | 1–2d | liveness config completes within budget; H1 verdict recorded; any liveness counterexample validated line-by-line against the code before acceptance (§9) |
+| 3 | Spec A: locks/dirty/publish with fallback lock identity, two-map accurate config + fallback config; H5 compiler-footprint pre-step; **H2, H3, H5 verdicts** | 2–3d | both configs run; verdicts recorded **with their Contract-C-conditionality noted** (accurate-mode "holds" results are contingent on H4/H1/H5 resolutions — §3) |
+| 4 | Alignment completion: remaining anchors + cross-reference tables, replay/stress tests for confirmed traces, CONTRIBUTING note, README completion (variable maps, atomicity table, sweeps, design decisions, verdict table as source of truth) | 1–2d | `verify_anchors.sh` green; README at echidna standard |
+| 5 | Fix PRs for confirmed defects (one per hypothesis: fix + replay test + flipped TLC verdict + anchor moved to fix site), then stretch items as appetite allows | open | each fix lands with its regression evidence; Spec A accurate-mode results re-validated once Contract C holds |
+| — | **Stretch (unscheduled):** machine-checked refinement B ⊑ A; Apalache inductive-invariant pass over `TallyIsUpstreamCount`; full trace validation via the sync-point seam; strong-fairness/FIFO-queue escalation if §9's fairness caveat bites | — | — |
+
+Total for phases 0–4: **8–11 focussed days.** Phase ordering note: B before A because
+B's verdicts (H1/H4) are pure protocol races with no policy judgement attached —
+faster payoff and the strongest fidelity test of the modelling approach — and because
+Contract C (checked by B) is the assumption A consumes. The oracle test rides with
+Phase 1 because it is the cheapest real-code evidence in the whole plan and depends
+on nothing TLA-related.
+
+## 9. Risks & Mitigations
+
+| Risk | Mitigation |
+|---|---|
+| **Fidelity** — model atomicity coarser than CE reality ⇒ verifying a different algorithm | Atomicity mapping table (§5) reviewed against code line-by-line; H1–H5 as acceptance tests — a model that can't reproduce suspected races is rejected, not trusted |
+| **State explosion**, especially with fiber-level granularity | Finiteness engineering (§5): pending-work sets, no dynamic fiber spawning, CONSTANT bounds + CONSTRAINT backstops; measured state-count spike before configs lock; split cfgs; symmetry in safety runs only (TLC forbids symmetry + liveness); deep sweeps manual |
+| **Weak fairness is not CE-faithful** — WF on a contended acquire isn't continuously enabled, so TLC can emit starvation lassos CE's FIFO semaphore excludes; conversely a spurious lasso could be misread as the H1 trace | Every liveness counterexample is validated line-by-line against the code before acceptance; pre-planned escalation: strong fairness on acquire actions or an explicit FIFO wait-queue model (stretch row, §8) |
+| **Bounded runs oversold** — "no counterexample" at small bounds is not unreachability | Verdict category is "no counterexample at stated bounds + written mechanism argument" (§6); each hypothesis row justifies its bounds; H2's one-map/two-map history kept as the cautionary example |
+| **Spec drift** | Anchors added per-PR + path-triggered CI + CONTRIBUTING rule (§7) |
+| **False-alarm anomalies** — snapshot-validity stronger than serializability | History-based fallback checker, built only if the strong form fails outside the H5 mechanism (§4) |
+| **Misjudged intent** — a "defect" may be a deliberate trade-off (H3 fallback likeliest) | Every verdict is a decision point with a trace attached (§6); no fix is presumed |
+| **CI cost/flakiness** | Config sizes locked from measured spike data; per-config matrix or ~30-min timeout (§2); `workflow_dispatch` escape hatch for deep runs (echidna pattern) |
+
+## 10. Observations Out of Scope (recorded, not modelled)
+
+- **Runtime-ID collisions:** IDs are `UUID.nameUUIDFromBytes(…).hashCode()` — 32-bit,
+  birthday bound ≈ 77k entities for a 50% pairwise-collision chance somewhere. A
+  collision conflates two vars in the log map (silent entry overwrite) and in
+  footprints. The specs `ASSUME` distinct IDs; the risk is documented in
+  `specs/README.md` and is property-test / arithmetic territory, not TLC territory.
+- **Data-dependent footprints:** a txn whose access set depends on values read may
+  have a different actual footprint on re-execution than the refined declared
+  footprint from its previous run. Spec B models declared footprints per incarnation
+  (§5) but actual footprints as fixed per txn. Revisit only if H3/H5 verdicts make
+  refinement soundness load-bearing.
+- **Semaphore fairness:** CE `Semaphore` is FIFO; the model uses weak fairness, which
+  is *weaker in a way that can matter* — see the fairness row in §9 for the
+  validation discipline and escalation path.

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,304 @@
+# TLA+ Formal Specifications
+
+Formal specifications of bengal-stm's transaction scheduling and commit
+protocols, verified with the TLC model checker. The plan, architecture
+rationale, and hypothesis list live in
+[`docs/plans/formal-specs.md`](../docs/plans/formal-specs.md); this README is
+the operational reference and the **source of truth for verdicts**.
+
+## What These Specs Verify
+
+**Footprint compatibility relation** (`src/main/scala/bengal/stm/model/runtime/IdFootprint.scala`):
+
+- The exact `isCompatibleWith` / `getValidated` semantics, encoded once in
+  `common/Footprint.tla` and shared by every other spec
+- Algebraic lemmas: symmetry, validation idempotence (the re-application
+  half of the `isValidated` flag's soundness — the other half is call-site
+  discipline, see the `IdFootprint.scala` anchor), validation monotonicity,
+  writer self-incompatibility
+- Pins of current behaviour with protocol consequences, including the **H5
+  read gap**: a parent-structure READ is judged compatible with a child-entry
+  WRITE (whole-map read vs new-key insert) — see the verdict table
+
+**Scheduler protocol, Phase 1 scope** (`src/main/scala/bengal/stm/runtime/TxnRuntimeContext.scala`):
+
+- Submission and dependency-graph construction, tallies, statuses,
+  unsubscribe cascades, the dirty-resubmission path, and the
+  `handleErrorWith` recovery branches
+- Six safety invariants over that machinery — all six currently **fail
+  organically** (no failure injection); see the verdict table
+
+**They do not verify (Phase 1):**
+
+- The retry map / park / wake machinery (`TxnResultRetry`) — Phase 2
+- The commit protocol's internals: lock ordering, dirty-check, publish
+  (Spec A, `commit/`) — Phase 3; Spec B treats commit as one atomic step
+- The free-monad compiler / static-analysis walker
+- `TxnLog` bookkeeping, value semantics (vars are version counters here)
+- Cancellation, `TxnVarMap.internalStructureLock` (leaf lock below the
+  modelled `commitLock`s), runtime-ID hash collisions (assumed distinct —
+  IDs are 32-bit UUID-hash-derived, `TxnStateEntity.scala:36-37`, so
+  collisions are possible at scale but are a property-test concern)
+
+## Specs
+
+| Spec | What it models | Scala correspondence |
+|------|----------------|----------------------|
+| `common/Footprint.tla` | The footprint data model and compatibility relation (operators only) | `IdFootprint.scala`, `TxnVarRuntimeId.scala` |
+| `common/FootprintLemmas.tla` | Exhaustive lemma checks over a 4-id universe (256 footprints, 65,536 ordered pairs) as named `ASSUME`s | `IdFootprint.scala` |
+| `scheduler/Scheduler.tla` | Spec B: the scheduler protocol at Ref/TrieMap-operation granularity | `TxnRuntimeContext.scala` |
+| `commit/` | Spec A: commit protocol (locks, dirty-check, publish) | **Phase 3 — not yet written** |
+
+`scheduler/Footprint.tla` and `commit/Footprint.tla` are symlinks to
+`common/Footprint.tla` — TLC resolves `EXTENDS` from the root module's
+directory, and symlinks keep the relation single-sourced without library-path
+flags. (Windows contributors need `git config core.symlinks true` on a
+filesystem that supports them, or the links materialise as one-line text
+files and TLC fails to parse; CI is Linux and unaffected.)
+
+Spec comments cite Scala **symbol names**, not line numbers — line references
+rot on every edit and `verify_anchors.sh` cannot guard them.
+
+## Prerequisites
+
+- **Java 11+** (tested with Java 21)
+- **tla2tools.jar** in this directory (gitignored) — download from
+  [TLA+ releases](https://github.com/tlaplus/tlaplus/releases):
+  ```bash
+  curl -sL -o specs/tla2tools.jar \
+    https://github.com/tlaplus/tlaplus/releases/download/v1.8.0/tla2tools.jar
+  ```
+  Note: the `v1.8.0` tag is a **rolling pre-release** — it serves current
+  nightly builds, so local and CI versions track each other but are not
+  byte-stable over time.
+
+## Running the Model Checker
+
+From the repository root. Every result below is asserted by
+`specs/check_expected.sh`, which encodes whether a run is expected clean or
+expected to reproduce a **pinned counterexample** (an EXPECTED-RED verdict):
+
+```bash
+# Footprint lemmas — expected clean, ~1s
+./specs/check_expected.sh specs/common/FootprintLemmas.cfg \
+    specs/common/FootprintLemmas.tla NONE
+
+# Scheduler evidence config — expected RED: pinned H4 counterexample
+# (NoDoubleExec violated at TLC search depth ~50), ~2s
+./specs/check_expected.sh specs/scheduler/Scheduler.cfg \
+    specs/scheduler/Scheduler.tla NoDoubleExec
+
+# Raw TLC invocation (traces print to stdout; TTrace files are gitignored):
+java -XX:+UseParallelGC -cp specs/tla2tools.jar tlc2.TLC \
+    -config specs/scheduler/Scheduler.cfg specs/scheduler/Scheduler.tla \
+    -workers auto -deadlock
+```
+
+`-deadlock` is required: terminal states (all transactions completed, or a
+zombie left by an aborted submission) have no successors by design, and TLC's
+default deadlock detection would report them as errors.
+
+CI (`.github/workflows/specs.yml`) runs `verify_anchors.sh` and then both
+checks above on every change to `specs/**` or the in-scope runtime sources
+(plus a `workflow_dispatch`-gated robustness check). A pinned-red check
+failing means the counterexample stopped reproducing — either the protocol
+changed, or the rolling TLC build drifted (the `v1.8.0` tag is a nightly);
+investigate which before touching the pin. The coupling is deliberate: fix
+and spec must move together (update this verdict table, the cfg pin, and the
+hypothesis rows in the plan).
+
+## Verdict Table (source of truth)
+
+Scenario for all Scheduler rows: 3 txns / 2 vars, `t1` under-declared (empty
+footprint — the static-analysis fallback in `TxnRuntime.commit`), `t2`
+accurately declaring a write to the same var, `t3` accurately declaring a
+read of it; `MaxInc=2`, `MaxVer=6`, no failure injection. All six defect
+verdicts fire at TLC search depths 50–64, below the depth-72 truncation boundary
+(`NoDroppedSpawn` below), so none of them is an artifact of the two-slot
+fiber bound.
+
+| Property | Verdict | Evidence |
+|----------|---------|----------|
+| `LemmaCompatSymmetric`, `LemmaValidatedIdempotent`, `LemmaValidatedPreservesUpdates`, `LemmaValidatedMonotoneCompat`, `LemmaWriterSelfIncompatible` | **HOLD** (exhaustive at 4-id universe) | `FootprintLemmas.cfg`, clean |
+| `DocumentsReadGapH5` — parent-structure read vs child-entry write judged **compatible** | **PINNED** (current behaviour; relation-level H5 premise confirmed) | `FootprintLemmas.cfg`; flips RED when the relation is fixed |
+| `DocumentsSiblingInsertsCompatible` — two new-key inserts to one map compatible (H2 enabler) | **PINNED** (correct behaviour; the hazard is the lock aliasing, Spec A) | `FootprintLemmas.cfg` |
+| `NoDoubleExec` | **RED — organic, pinned in CI** (TLC search depth ~50, 49-state trace) | H4 counterexample, narrative below |
+| `ContractC` | **RED — organic** (depth ~51) | same root cause; drop-and-rerun procedure below |
+| `NoExecOnCompleted` | **RED — organic** (depth ~58) | 〃 |
+| `NoDoublePublish` | **RED — organic** (depth ~58) | 〃 |
+| `TallyNonNegative` | **RED — organic** (depth ~60) | 〃 |
+| `CompletionAtMostOnce` | **RED — organic** (depth ~64) | 〃 |
+| `NoDroppedSpawn` | **RED at depth ~72 — a model-capacity boundary, not a code defect** | the two-slot fiber bound truncates real behaviour from depth ~72 on (a third concurrent execute is reachable in code); enumeration results beyond that depth would need widened slots |
+| `TypeOK` | holds on every completed run | all cfgs |
+
+**H4 counterexample narrative** (validated line-by-line against the code;
+minimal 49-state trace (TLC search depth ~50), `Scheduler.cfg`):
+
+1. `t1` (empty declared footprint) and `t2` (writes `V1`) are judged
+   compatible — under-declaration hides the conflict — and run concurrently.
+   Both actually write `V1`; `t1` publishes first; `t2`'s commit validation
+   (`isDirty` under `withLock`) finds `V1` moved and returns dirty.
+2. `t2`'s completion fires `triggerUnsub.start` — fire-and-forget, inside
+   `registerCompletion` — then resubmits itself via
+   `submitTxnForImmediateRetry` with a `this.copy` that **shares
+   `unsubSpecs` and `dependencyTally`** across incarnations.
+3. Meanwhile `t3` submitted via `submitTxn`, saw an empty active set, and
+   its `checkExecutionReadiness` **already spawned its execute fiber**, now
+   parked at `registerRunning` waiting for the graph semaphore.
+4. `t2`'s resubmission scan sees `t3` as `Scheduled` and adds the reversed
+   dependency edge (`subscribeDownstreamDependency`: `tally[t3] += 1`,
+   `unsubs[t2] += t3`) — the edge assumes `t3` has not started, but its
+   fiber is already in flight and `registerRunning` re-checks nothing.
+5. `t2`'s **old** cascade (step 2) now reads the **new** incarnation's edge
+   out of the shared `unsubSpecs` and drains it
+   (`unsubscribeUpstreamDependency`): `tally[t3]` 1→0, old == 1 spawns a
+   **second** execute fiber for `t3`.
+6. Nothing dedupes execute fibers → `t3` executes twice: `NoDoubleExec`
+   (both fibers in the commit window), then downstream `NoDoublePublish`
+   (the log commits twice — double effect application for non-idempotent
+   transactions), `CompletionAtMostOnce` (second completion),
+   `NoExecOnCompleted`, `TallyNonNegative` (stale drains under-run the
+   reset tally), and `ContractC` (a stale fiber in-window alongside an
+   incompatible peer).
+
+**Reproducing the non-pinned RED verdicts:** copy `Scheduler.cfg`, list the
+invariant of interest (dropping any that fail shallower — the order above is
+shallowest-first), and run TLC. Each halts within seconds at the quoted
+depth.
+
+**Robustness config** (`scheduler/SchedulerAborts.cfg`, run manually or via
+the `workflow_dispatch`-gated CI step): enables nondeterministic failure
+injection at every point a `handleErrorWith` can observe (`execute`'s
+handler and the submit wrapper in `TxnRuntime.commit`). Measured and pinned:
+`CompletionAtMostOnce` violated at **depth 16** — a submit-wrapper abort
+landing after the readiness check completes the caller's signal with an
+error while the already-spawned execute commits and completes again: a
+spurious failure report on a transaction that published. The
+double-`registerCompletion` path (second unsubscribe cascade) is also in
+scope here. These runs assert protocol *robustness to* exceptions, not that
+any particular throw is organically reachable; mid-publish throws are inside
+the atomic-commit abstraction and out of scope (Spec A territory). With the
+organic verdicts already red these runs add evidence, not new invariant
+flips.
+
+## Invariant Cross-Reference
+
+Each anchored invariant carries a `// SPEC: <Name>` comment at the code site
+that realises (or, for EXPECTED-RED rows, *fails to guard*) it —
+`specs/verify_anchors.sh` parses these tables and greps the declared file,
+failing CI if an anchor disappears. For expected-red invariants the anchor
+marks the **mechanism site**; it moves to the fix site when the fix lands.
+
+### Scheduler protocol (anchors in `src/main/scala/bengal/stm/runtime/TxnRuntimeContext.scala`)
+
+| TLA+ Invariant | Anchor site | Status at anchor |
+|---------------|-------------|------------------|
+| `NoDoubleExec` | `src/main/scala/bengal/stm/runtime/TxnRuntimeContext.scala` | execute spawn sites (readiness + tally zero-test) have no dedup guard — EXPECTED RED |
+| `TallyNonNegative` | `src/main/scala/bengal/stm/runtime/TxnRuntimeContext.scala` | the `getAndUpdate(_ - 1)` decrement is the only tally sink; stale shared-`unsubSpecs` edges under-run it — EXPECTED RED |
+| `NoExecOnCompleted` | `src/main/scala/bengal/stm/runtime/TxnRuntimeContext.scala` | `registerRunning` re-checks neither tally nor completion — EXPECTED RED |
+| `ContractC` | `src/main/scala/bengal/stm/runtime/TxnRuntimeContext.scala` | the submit scan is the intended conflict-avoidance mechanism — EXPECTED RED |
+| `CompletionAtMostOnce` | `src/main/scala/bengal/stm/runtime/TxnRuntimeContext.scala` | completion sites (success, error handler, submit wrapper) — EXPECTED RED |
+| `NoDoublePublish` | `src/main/scala/bengal/stm/runtime/TxnRuntimeContext.scala` | `log.commit` publishes; a second fiber re-publishes — EXPECTED RED |
+
+### Footprint relation (anchors in `src/main/scala/bengal/stm/model/runtime/IdFootprint.scala`)
+
+| TLA+ Invariant | Anchor site | Status at anchor |
+|---------------|-------------|------------------|
+| `LemmaValidatedIdempotent` | `src/main/scala/bengal/stm/model/runtime/IdFootprint.scala` | one `getValidated` application is a fixpoint — HOLDS, makes the memoisation flag sound |
+| `DocumentsReadGapH5` | `src/main/scala/bengal/stm/model/runtime/IdFootprint.scala` | the parent rule tests ids only against the other side's update set — PINNED current behaviour (H5) |
+
+## Variable Mapping (Scheduler.tla)
+
+| TLA+ variable | Scala |
+|---------------|-------|
+| `status[t]` | `AnalysedTxn.executionStatus: Ref[F, ExecutionStatus]` — never demoted, exactly as in the code (nothing writes it after `Running` except a resubmission's `set(Scheduled)`); completion is visible only via `completedCount` |
+| `tally[t]` | `AnalysedTxn.dependencyTally: Ref[F, Int]` — shared across incarnations via `copy` |
+| `unsubs[t]` | `AnalysedTxn.unsubSpecs: MutableMap[TxnId, F[Unit]]` (edge set; the `F[Unit]` values are the downstream decrements) — shared across incarnations |
+| `hasDown[t]` | `AnalysedTxn.hasDownstream: Ref[F, Boolean]` |
+| `completedCount[t]` | completions of `AnalysedTxn.completionSignal: Deferred` (counted to detect doubles; the real `Deferred` is first-wins) |
+| `inc[t]`, `declared[t]` | incarnation ordinal and that incarnation's validated footprint (`idFootprint`, refined on the dirty path) |
+| `snap[t, slot]`, `version[v]` | abstraction of log-entry `initial` captures (per execute fiber — each run builds a private log) and committed var state (values → version counters) |
+| `submitPc[t]`, `scanPending[t]`, `curTarget/curDir/curContained` | position inside `submitTxn` / `submitTxnForImmediateRetry` and the scan loop |
+| `exec[t, slot]` | in-flight `execute` fibers (two slots — double-spawn must be representable) |
+| `unsubW[t, slot]` | in-flight `triggerUnsub` cascades (two slots — the error path spawns a second) |
+| `active` | `TxnScheduler.activeTransactions` keys |
+| `graphSem` | `graphBuilderSemaphore` holder (`retrySemaphore` arrives with Phase 2) |
+
+## Atomicity Mapping & Reductions
+
+One model step = one operation on one shared mutable object: each `Ref`
+`get`/`set`/`update`/`getAndUpdate`, each `TrieMap` read/insert/remove.
+Check-then-act sequences are two steps (the `unsubSpecs` contains-check is
+deliberately separate from the subscribe writes — that gap is H4's home).
+Semaphore-guarded regions are *not* atomic: unsubscribe-cascade steps
+interleave with in-region steps. Documented reductions:
+
+| # | Reduction | Justification |
+|---|-----------|---------------|
+| R1 | Scan fibers → sequential loop, fixed order | inter-fiber steps touch disjoint cells apart from monotone tally increments; external interleavings preserved between every pair of loop steps |
+| R2 | Subscribe triple (tally++, insert, hasDown) → one step | cascades do read and `clear()` the `unsubs` cell concurrently, but every torn-triple interleaving coincides observably with some atomic placement of the triple relative to `snapVals`/`clear` steps; the contains-check stays separate (that gap is H4's home) |
+| R3 | acquire/act/release → one guarded step for single-op semaphore regions (`registerRunning`, the active-set remove) | nothing else can run under the held semaphore in a one-op region |
+| R4 | Static analysis, `AnalysedTxn` construction, `Deferred` creation → `Init` | pre-protocol, no shared state contention |
+| R5 | Concurrent `submitTxnForImmediateRetry` runs of one txn → serialized (one submit workflow per txn) | **unjustified reduction, accepted for Phase 1** — the code runs each dirty fiber's resubmission inline, so two dirty fibers race their resets/scans; that region only exists after a `NoDoubleExec` violation, and enumeration traces from it are re-validated against the code individually; per-slot submit machinery is Phase 2 rework |
+| — | `triggerUnsub`'s nonEmpty check and values snapshot NOT collapsed | a concurrent `clear()` between them is a real trace (double-spawned cascades) |
+| — | Commit → one atomic truthful step (dirty iff a written var moved since **this fiber's** snapshot; snapshots are per-slot) | Spec B's contract with Spec A (plan §3); Spec A refines lock/validate/publish |
+| — | Two exec slots + two cascade slots per txn, `droppedSpawn` ghost | a third spawn is reachable in code (from depth ~72 in this scenario); the ghost turns any silent drop into a `NoDroppedSpawn` violation instead of an invisible truncation |
+
+Failure injection (`AbortsEnabled`): a nondeterministic abort at any point
+the corresponding `handleErrorWith` covers. The model does not claim any
+specific organic throw site — injection runs measure robustness, and their
+verdicts are labelled accordingly.
+
+## Parameter Sweeps & State-Space Data
+
+Measured on 12 cores (Apple x86_64, JDK 21, TLC 2026-07 build):
+
+- **Violation runs** (`Scheduler.cfg` and drop-and-rerun variants): halt in
+  **1–3 s** at TLC search depths 50–64 (the `NoDroppedSpawn` boundary run reaches
+  depth 72 in ~20 s / 1.2M distinct states); 4k–120k distinct states for
+  the defect verdicts. CI-friendly.
+- **Full organic sweep** at `MaxInc=2, MaxVer=6` (no protocol invariants):
+  **infeasible** — >32M distinct states after 10 min (~18M states/min
+  generated, ~3.4M distinct/min), queue still growing at depth 98.
+- Consequence: post-fix **green** verification of Spec B needs tighter
+  bounds (`MaxInc=1`, smaller `MaxVer`, or 2-txn scenarios) — sized when a
+  fix PR needs them (plan Phase 5). Expected-red pins are unaffected.
+
+## Design Decisions
+
+- **Raw TLA+, named-`ASSUME` lemma modules, per-concern `.cfg`s** — echidna
+  house pattern (`../echidna/specs`).
+- **Compatibility is always computed, never hand-assigned.** Scenario
+  footprints go through `common/Footprint.tla`'s `IsCompatible`/`Validated`;
+  an early plan draft mis-reasoned a compatibility by hand (H2) and this rule
+  exists so that cannot recur.
+- **Strings as txn ids, records as var ids.** Runtime IDs are arbitrary
+  distinct naturals chosen per scenario; the real system's hash-derived IDs
+  make every ordering class reachable.
+- **Two exec slots / two cascade slots per txn, with a drop detector.**
+  Double-spawn and double-cascade are the defects under test; the model must
+  represent them. A third spawn is dropped, and — since that is reachable
+  *before* any invariant fires — every drop sets the `droppedSpawn` ghost so
+  `NoDroppedSpawn` reports the truncation explicitly (RED at depth ~72 in
+  the shipped scenario).
+- **`status` matches the code exactly**: never demoted (nothing writes it
+  after `Running` except a resubmission's `set(Scheduled)`), so scans read
+  the same values the code would. Completion is tracked by `completedCount`
+  alone, and Contract C's window is encoded from exec-fiber position, not
+  status.
+- **Expected-red pins over green-washing.** Where the protocol is defective,
+  CI asserts the counterexample *reproduces* rather than skipping the check —
+  the spec stays load-bearing while the defect exists, and the flip to green
+  is forced through this README and the plan together.
+
+## Keeping Specs and Code in Sync
+
+1. **Source anchors** (`// SPEC: <Name>`) verified by
+   `specs/verify_anchors.sh` in CI — see the cross-reference tables above.
+2. **Pinned expectations** via `specs/check_expected.sh` in CI — clean specs
+   must stay clean, and confirmed counterexamples must keep reproducing
+   until the code is fixed.
+3. **Semantic property tests** (planned, plan §7): a serializability oracle
+   test in `src/test/scala/spec/` exercising generated workloads against a
+   global-lock reference STM, plus deterministic replay/stress tests for
+   each confirmed trace as fixes land.

--- a/specs/check_expected.sh
+++ b/specs/check_expected.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Run TLC on a spec and assert the EXPECTED outcome:
+#
+#   ./specs/check_expected.sh <config.cfg> <module.tla> NONE
+#       — require a clean run ("No error has been found").
+#
+#   ./specs/check_expected.sh <config.cfg> <module.tla> <InvariantName>
+#       — require TLC to report exactly "Invariant <InvariantName> is
+#         violated". This pins an EXPECTED-RED verdict: the spec documents a
+#         confirmed defect, and CI fails if the counterexample stops
+#         reproducing (e.g. the protocol was fixed) so that the spec, the
+#         verdict table in specs/README.md, and the plan's hypothesis rows
+#         get updated together.
+#
+# Run from the repository root. TLC's jar is expected at specs/tla2tools.jar.
+
+# NOTE: deliberately NO `set -e` — TLC exits nonzero on expected violations
+# (the entire point of a pinned-red run); the exit code is captured and
+# interpreted below instead. Adding -e would kill every pinned-red check.
+set -uo pipefail
+
+CFG="${1:?usage: check_expected.sh <cfg> <tla> <NONE|InvariantName>}"
+TLA="${2:?usage: check_expected.sh <cfg> <tla> <NONE|InvariantName>}"
+EXPECTED="${3:?usage: check_expected.sh <cfg> <tla> <NONE|InvariantName>}"
+
+OUT="$(mktemp)"
+trap 'rm -f "$OUT"' EXIT
+
+java -XX:+UseParallelGC -cp specs/tla2tools.jar tlc2.TLC \
+    -config "$CFG" "$TLA" -workers auto -deadlock >"$OUT" 2>&1
+TLC_EXIT=$?
+
+if [[ "$EXPECTED" == "NONE" ]]; then
+  if [[ $TLC_EXIT -eq 0 ]] && grep -q "No error has been found" "$OUT"; then
+    echo "OK: $TLA ($CFG) — clean run, as expected."
+    exit 0
+  fi
+  echo "UNEXPECTED: $TLA ($CFG) should verify cleanly but did not (exit $TLC_EXIT):" >&2
+  tail -40 "$OUT" >&2
+  exit 1
+fi
+
+if grep -q "Invariant $EXPECTED is violated" "$OUT"; then
+  echo "OK: $TLA ($CFG) — reproduced the pinned counterexample ($EXPECTED)."
+  exit 0
+fi
+
+echo "UNEXPECTED: $TLA ($CFG) did not reproduce the pinned $EXPECTED violation (exit $TLC_EXIT)." >&2
+echo "If the protocol was fixed, update the verdict table in specs/README.md," >&2
+echo "the hypothesis rows in docs/plans/formal-specs.md, and this CI expectation." >&2
+tail -40 "$OUT" >&2
+exit 1

--- a/specs/commit/Footprint.tla
+++ b/specs/commit/Footprint.tla
@@ -1,0 +1,1 @@
+../common/Footprint.tla

--- a/specs/common/Footprint.tla
+++ b/specs/common/Footprint.tla
@@ -1,0 +1,84 @@
+------------------------------ MODULE Footprint ------------------------------
+(*
+ * Exact TLA+ encoding of bengal-stm's footprint compatibility relation.
+ *
+ * This module is operators-only (no variables, no behaviour) and is EXTENDed
+ * by both Scheduler.tla (Spec B) and CommitProtocol.tla (Spec A) so that
+ * "compatible" means precisely the same thing everywhere. Scenario configs
+ * must never hand-assign compatibility between transactions — it is always
+ * computed by these operators. (The plan's H2 hypothesis was misdiagnosed in
+ * an early draft precisely by hand-reasoning compatibility; this module is
+ * the guard against repeating that.)
+ *
+ * Scala correspondence:
+ *   - TxnVarRuntimeId(value: Int, parent: Option[TxnVarRuntimeId])
+ *     An id is modelled as [val |-> Nat, par |-> Nat or NoParent]. Only the
+ *     parent's raw value is ever consulted by the relation, so `par` holds
+ *     the parent's value directly rather than a nested record.
+ *   - IdFootprint(readIds, updatedIds)
+ *     Modelled as [reads |-> set of ids, updates |-> set of ids]. The Scala
+ *     `isValidated` boolean is a memoisation flag, not semantics. The
+ *     ValidatedIdempotent lemma (FootprintLemmas.tla) covers its
+ *     re-application half; the other half is call-site discipline, since
+ *     the Scala mutators copy the flag through (see the IdFootprint.scala
+ *     anchor).
+ *
+ * Runtime IDs in the real system are UUID-hash-derived Ints
+ * (TxnStateEntity.runtimeId); collisions are possible but are excluded
+ * here by construction (distinct model ids). This ASSUMPTION is recorded in
+ * specs/README.md.
+ *)
+
+EXTENDS Naturals, FiniteSets
+
+CONSTANT NoParent
+
+FP(reads, updates) == [reads |-> reads, updates |-> updates]
+
+EmptyFootprint == FP({}, {})
+
+(* combinedIds *)
+CombinedIds(f) == f.reads \cup f.updates
+
+(* combinedRawIds *)
+CombinedRawIds(f) == { id.val : id \in CombinedIds(f) }
+
+(* updateRawIds *)
+UpdateRawIds(f) == { id.val : id \in f.updates }
+
+(* mergeWith *)
+MergeWith(f, g) ==
+    FP(f.reads \cup g.reads, f.updates \cup g.updates)
+
+(*
+ * asymmetricCompatibleWith:
+ *   combinedRawIds.intersect(input.updateRawIds).isEmpty &&
+ *     !combinedIds.exists(_.parent.exists(p => input.updateRawIds.contains(p.value)))
+ *
+ * Note the known asymmetry gap (hypothesis H5): each side's ids — reads
+ * included — are tested against the OTHER side's UPDATE ids only. A child
+ * WRITE on this side is caught against a parent WRITE on the other side
+ * (second conjunct, evaluated from the child's side), but a child WRITE is
+ * never tested against a parent READ. FootprintLemmas.tla pins this down.
+ *)
+AsymCompat(f, g) ==
+    /\ CombinedRawIds(f) \cap UpdateRawIds(g) = {}
+    /\ ~\E id \in CombinedIds(f) :
+            id.par /= NoParent /\ id.par \in UpdateRawIds(g)
+
+(* isCompatibleWith *)
+IsCompatible(f, g) == AsymCompat(f, g) /\ AsymCompat(g, f)
+
+(*
+ * getValidated:
+ *   readIds := (readIds -- updatedIds)
+ *                .filter(id => id.parent.forall(pid => !updateRawIds.contains(pid.value)))
+ * i.e. drop reads that this footprint also updates (structural id equality),
+ * and drop reads whose parent's raw value is among this footprint's updates.
+ *)
+Validated(f) ==
+    FP({ id \in (f.reads \ f.updates) :
+            id.par = NoParent \/ id.par \notin UpdateRawIds(f) },
+       f.updates)
+
+===============================================================================

--- a/specs/common/FootprintLemmas.cfg
+++ b/specs/common/FootprintLemmas.cfg
@@ -1,0 +1,7 @@
+\* Footprint relation lemmas — exhaustive over the 4-id universe (256 footprints).
+\* All checking happens in the named ASSUMEs at TLC startup; the behaviour spec
+\* is a single-state stutter.
+CONSTANT
+    NoParent = NoParent
+INIT Init
+NEXT Next

--- a/specs/common/FootprintLemmas.tla
+++ b/specs/common/FootprintLemmas.tla
@@ -1,0 +1,154 @@
+--------------------------- MODULE FootprintLemmas ---------------------------
+(*
+ * Lemma checks over the footprint compatibility relation (Footprint.tla),
+ * evaluated exhaustively by TLC over a small concrete id universe as named
+ * ASSUMEs. TLC verifies every ASSUME at startup; on failure it reports the
+ * assumption's LOCATION (line/column), not its name — the names are for
+ * reading and grep.
+ *
+ * The universe: one plain var, one map structure id, and two entry ids
+ * parented to that structure — the minimal shape that exercises every branch
+ * of the relation (raw intersection, parent rule, both asymmetric directions).
+ *
+ *   PV1 : plain TxnVar
+ *   S   : TxnVarMap structural id       (TxnStateEntity.runtimeId)
+ *   E1  : map entry, parent = S         (TxnVarMap.getRuntimeId)
+ *   E2  : map entry, parent = S, E2 /= E1
+ *
+ * Quantified lemmas range over all 2^4 x 2^4 = 256 footprints on this
+ * universe (65,536 ordered pairs) — exhaustive and fast.
+ *
+ * TWO KINDS OF LEMMA LIVE HERE — read the labels carefully:
+ *
+ *   Lemma*    — properties the relation SHOULD have and does. A failure
+ *               means the Footprint.tla encoding drifted from intent (or a
+ *               code change broke the relation's algebra).
+ *
+ *   Documents* — pins of CURRENT behaviour, including behaviour suspected
+ *               to be defective. In particular DocumentsReadGapH5 asserts
+ *               that a parent-structure READ is judged compatible with a
+ *               child-entry WRITE — the hypothesised phantom-write-skew hole
+ *               (plan §6, H5). If isCompatibleWith is ever fixed to close
+ *               that gap, this ASSUME goes RED on purpose: update the lemma,
+ *               Footprint.tla, the verdict table in specs/README.md, and the
+ *               H5 row together.
+ *)
+
+EXTENDS Footprint
+
+PV1 == [val |-> 1, par |-> NoParent]
+S   == [val |-> 3, par |-> NoParent]
+E1  == [val |-> 4, par |-> 3]
+E2  == [val |-> 5, par |-> 3]
+
+Ids == {PV1, S, E1, E2}
+
+Footprints == [reads : SUBSET Ids, updates : SUBSET Ids]
+
+-------------------------------------------------------------------------------
+(* Algebraic properties of the relation as encoded *)
+-------------------------------------------------------------------------------
+
+(* isCompatibleWith is symmetric by construction — a conjunction of both
+   asymmetric directions *)
+ASSUME LemmaCompatSymmetric ==
+    \A f \in Footprints, g \in Footprints :
+        IsCompatible(f, g) <=> IsCompatible(g, f)
+
+(* getValidated is a fixpoint after one application. This covers the
+   re-application half of the isValidated memoisation flag's soundness;
+   the other half is call-site discipline — addReadId/addWriteId/mergeWith
+   copy the flag through without resetting it, so validated footprints
+   must not be mutated afterwards (see the anchor in IdFootprint.scala). *)
+ASSUME LemmaValidatedIdempotent ==
+    \A f \in Footprints :
+        Validated(Validated(f)) = Validated(f)
+
+(* Validation never touches the update set *)
+ASSUME LemmaValidatedPreservesUpdates ==
+    \A f \in Footprints :
+        Validated(f).updates = f.updates
+
+(* Validation only removes reads, so it can only relax the relation:
+   compatible footprints stay compatible after validation. The scheduler
+   compares getValidated footprints everywhere (TxnRuntime.commit and the
+   dirty-path refinement), so this direction is the one the runtime relies
+   on. *)
+ASSUME LemmaValidatedMonotoneCompat ==
+    \A f \in Footprints, g \in Footprints :
+        IsCompatible(f, g) => IsCompatible(Validated(f), Validated(g))
+
+(* A footprint that updates anything conflicts with itself — relevant to the
+   retry map, which compares parked footprints against submitted ones *)
+ASSUME LemmaWriterSelfIncompatible ==
+    \A f \in Footprints :
+        f.updates /= {} => ~IsCompatible(f, f)
+
+-------------------------------------------------------------------------------
+(* Positive controls: conflicts the relation DOES catch *)
+-------------------------------------------------------------------------------
+
+(* Plain write-write on the same id *)
+ASSUME DocumentsWriteWriteCaught ==
+    ~IsCompatible(FP({}, {PV1}), FP({}, {PV1}))
+
+(* Plain read-write on the same id *)
+ASSUME DocumentsReadWriteCaught ==
+    ~IsCompatible(FP({PV1}, {}), FP({}, {PV1}))
+
+(* Read-read is compatible *)
+ASSUME DocumentsReadReadCompatible ==
+    IsCompatible(FP({PV1}, {}), FP({PV1}, {}))
+
+(* Child-entry WRITE vs parent-structure WRITE is caught by the parent rule
+   (the child side's parent value hits the structure side's update set) *)
+ASSUME DocumentsParentWriteChildWriteCaught ==
+    ~IsCompatible(FP({}, {S}), FP({}, {E1}))
+
+(* Child-entry READ vs parent-structure WRITE is caught likewise *)
+ASSUME DocumentsParentWriteChildReadCaught ==
+    ~IsCompatible(FP({E1}, {}), FP({}, {S}))
+
+-------------------------------------------------------------------------------
+(* Pins of current behaviour with protocol-level consequences *)
+-------------------------------------------------------------------------------
+
+(*
+ * H5 (plan §6): parent-structure READ vs child-entry WRITE is judged
+ * COMPATIBLE. The parent rule tests ids only against the other side's
+ * UPDATE set, so E1.par = S.val is never compared against a mere read of S.
+ * Consequence: "read whole map" and "insert new key" can run concurrently
+ * under fully accurate footprints, and since structure reads are never
+ * commit-validated (TxnLogReadOnlyVarMapStructureEntry), phantom write skew is
+ * hypothesised reachable. Spec A (Phase 3) carries the behavioural check;
+ * this lemma pins the relation-level fact.
+ *
+ * IF THIS GOES RED: the relation was fixed. Flip the H5 verdict row and
+ * rewrite this lemma to assert the incompatibility.
+ *)
+ASSUME DocumentsReadGapH5 ==
+    IsCompatible(FP({S}, {}), FP({}, {E1}))
+
+(*
+ * Two new-key inserts into the SAME map (distinct keys) are compatible —
+ * neither writes the structure id, and the entry ids are distinct. This is
+ * what allows two such transactions to run concurrently and contend on the
+ * map's structural commitLock via the new-key lock fallback
+ * (TxnLogUpdateVarMapEntry.lock). With TWO maps this becomes H2's
+ * accurate-mode deadlock candidate (plan §6). Compatibility here is
+ * correct (the writes genuinely don't conflict); the hazard lives in the
+ * lock aliasing, which Spec A models.
+ *)
+ASSUME DocumentsSiblingInsertsCompatible ==
+    IsCompatible(FP({}, {E1}), FP({}, {E2}))
+
+-------------------------------------------------------------------------------
+(* Trivial behaviour so TLC has a spec to run; the ASSUMEs are the payload *)
+-------------------------------------------------------------------------------
+
+VARIABLE unused
+
+Init == unused = TRUE
+Next == UNCHANGED unused
+
+===============================================================================

--- a/specs/scheduler/Footprint.tla
+++ b/specs/scheduler/Footprint.tla
@@ -1,0 +1,1 @@
+../common/Footprint.tla

--- a/specs/scheduler/Scheduler.cfg
+++ b/specs/scheduler/Scheduler.cfg
@@ -1,0 +1,21 @@
+\* Spec B evidence config, ORGANIC protocol only (no failure injection) — run
+\* with -deadlock (terminal states with completed txns have no successors by
+\* design).
+\*
+\* EXPECTED RED (pinned): NoDoubleExec is violated at TLC search depth ~50 (49-state trace) — the H4
+\* counterexample (docs/plans/formal-specs.md §6), confirmed against the code.
+\* CI runs this via check_expected.sh, which FAILS if the counterexample
+\* stops reproducing. Only NoDoubleExec is listed so the report is
+\* deterministic; the other five organic violations (ContractC,
+\* NoExecOnCompleted, NoDoublePublish, TallyNonNegative,
+\* CompletionAtMostOnce) are enumerated in specs/README.md with the
+\* drop-and-rerun procedure to reproduce each.
+CONSTANT
+    NoParent = NoParent
+    MaxInc = 2
+    MaxVer = 6
+    AbortsEnabled = FALSE
+SPECIFICATION Spec
+CONSTRAINT StateConstraint
+INVARIANT TypeOK
+INVARIANT NoDoubleExec

--- a/specs/scheduler/Scheduler.tla
+++ b/specs/scheduler/Scheduler.tla
@@ -1,0 +1,696 @@
+------------------------------ MODULE Scheduler ------------------------------
+(*
+ * Spec B: the bengal-stm transaction scheduler protocol.
+ * Scala correspondence: TxnRuntimeContext.scala. Actions cite method names
+ * (submitTxn, subscribeDownstreamDependency, ...) rather than line numbers —
+ * line references rot on every comment edit and verify_anchors.sh cannot
+ * guard them; symbol names it can grep.
+ *
+ * PHASE 1 SCOPE (docs/plans/formal-specs.md §5, §8): submission and graph
+ * building, dependency tallies, execution statuses, unsubscribe cascades,
+ * the dirty-resubmission path (submitTxnForImmediateRetry), and the error
+ * recovery branches. The retry map / park / wake machinery (TxnResultRetry)
+ * is Phase 2 and absent here; the commit is Spec B's atomic version-bump
+ * abstraction (plan §3) — Spec A refines it.
+ *
+ * GRANULARITY (plan §5 atomicity mapping): one model step = one operation on
+ * one shared mutable object (Ref get/set/update, TrieMap read/insert/remove).
+ * Semaphore-guarded regions are NOT atomic — steps of detached fibers
+ * (unsubscribe cascades) interleave with in-region steps. Deliberate
+ * reductions, each argued in specs/README.md:
+ *   R1. The per-target subscribe fibers inside a submit scan (parTraverse of
+ *       .start'ed fibers, joined before region exit) are modelled as a
+ *       sequential loop in a fixed target order. Their steps touch disjoint
+ *       cells apart from monotone counter increments, so inter-fiber
+ *       orderings commute; interleavings with EXTERNAL steps are preserved
+ *       between every pair of loop steps.
+ *   R2. A subscribe's three writes (tally increment, unsubSpecs insert,
+ *       hasDownstream set) collapse to one step. External racers read only
+ *       the tally cell, and single-op interleavings before/after the triple
+ *       are preserved; the code's contains-check stays a SEPARATE step,
+ *       which is where the H4 staleness lives.
+ *   R3. Semaphore acquire/act/release collapses to one guarded step for
+ *       regions containing exactly one operation (registerRunning,
+ *       registerCompletion's remove).
+ *   R4. Static analysis, AnalysedTxn construction, and Deferred creation
+ *       collapse into Init.
+ * The nonEmpty check and values snapshot of triggerUnsub are deliberately
+ * NOT collapsed (two steps) — a clear() can land between them, and merging
+ * would hide real traces (double-spawned cascades from the error path).
+ *
+ * Commit outcomes are truthful, not nondeterministic: dirty iff a written
+ * var's version moved since this fiber's snapshot. A nondeterministic
+ * failure can strike the commit (before publish — a mid-publish throw is
+ * inside the atomic-commit abstraction and out of scope here) or the
+ * dispatch of a dirty resubmission — modelling `execute`'s handleErrorWith,
+ * which runs registerCompletion a SECOND time and starts a SECOND
+ * unsubscribe cascade — and a plain submission can abort, modelling the
+ * submit wrapper's handleErrorWith in TxnRuntime.commit, which completes
+ * the signal and leaves the transaction wherever it was.
+ *)
+
+EXTENDS Footprint, Integers, FiniteSets, Sequences
+
+CONSTANTS
+    MaxInc,          \* dirty-resubmission bound per txn (action-level
+                     \* truncation: ExecResubTruncate retires the fiber)
+    MaxVer,          \* version bound per var (CONSTRAINT backstop)
+    AbortsEnabled    \* enable the nondeterministic failure injections
+
+---------------------------------------------------------------------------
+(* Scenario — edit this section to vary the workload (Phase 2 may split
+   scenarios into their own modules). Runtime ids are arbitrary distinct
+   naturals; hash-derived order in the real system makes every ordering
+   class reachable (TxnStateEntity.runtimeId). *)
+---------------------------------------------------------------------------
+
+Txns == {"t1", "t2", "t3"}
+
+V1 == [val |-> 1, par |-> NoParent]
+V2 == [val |-> 2, par |-> NoParent]
+VarIds == {V1, V2}
+
+(* Actual access sets: what the transaction's log will really touch. *)
+ActualFP(t) ==
+    CASE t = "t1" -> FP({}, {V1})
+      [] t = "t2" -> FP({}, {V1})
+      [] t = "t3" -> FP({V1}, {V2})
+
+(* Declared base footprints: t1 under-declares (models the static-analysis
+   fallback in TxnRuntime.commit's handleErrorWith) — this is what lets t1
+   and t2 run concurrently, forces a dirty commit, and opens the H4 window. *)
+DeclaredBase(t) ==
+    CASE t = "t1" -> EmptyFootprint
+      [] t = "t2" -> FP({}, {V1})
+      [] t = "t3" -> FP({V1}, {V2})
+
+Writes(t) == ActualFP(t).updates
+TxnRank(t) == CASE t = "t1" -> 1 [] t = "t2" -> 2 [] t = "t3" -> 3
+
+---------------------------------------------------------------------------
+(* State *)
+---------------------------------------------------------------------------
+
+VARIABLES
+    \* --- per-txn protocol state (the AnalysedTxn refs; shared across
+    \*     incarnations exactly as the dirty path's this.copy shares them) ---
+    status,          \* executionStatus Ref — never demoted, as in the code;
+                     \* completion is visible only via completedCount
+    tally,           \* dependencyTally Ref (Int — negativity is detectable)
+    unsubs,          \* unsubSpecs TrieMap: t |-> set of downstream txn ids
+    hasDown,         \* hasDownstream Ref
+    completedCount,  \* completionSignal completions observed (Deferred)
+    inc,             \* incarnation counter (0 = first submission)
+    declared,        \* current incarnation's declared (validated) footprint
+    publishedInc,    \* ghost: this incarnation already published
+    doublePub,       \* ghost: a publish happened twice in one incarnation
+    droppedSpawn,    \* ghost: a spawn found no free slot (masking detector —
+                     \* if TRUE the two-slot bound truncated a real behaviour)
+    snap,            \* PER-FIBER version snapshot taken at execute start
+                     \* (each execute run builds a private log in the code,
+                     \* so concurrent fibers of one txn snapshot independently)
+    \* --- submit workflow (one per txn; resubmission reuses it) ---
+    submitPc,        \* "idle","reset1","reset2","acq","setSched","insAct",
+                     \* "scanPick","scanCheck","subCheck","subApply","ready","rel"
+    submitMode,      \* "plain" (submitTxn) | "imm" (submitTxnForImmediateRetry)
+    scanPending,     \* targets not yet scanned
+    curTarget,       \* target being scanned ("none" between targets)
+    curDir,          \* subscribe direction: "down" (target -> me) | "up" (me -> target)
+    curContained,    \* result of the unsubSpecs contains-check
+    \* --- execute fibers: two slots per txn (double-spawn is representable
+    \*     because detecting it is the point) ---
+    exec,            \* [Txns \X {"A","B"} -> [pc |-> ..., out |-> ...]]
+    \* --- triggerUnsub cascades: two slots per owner (error path spawns two) ---
+    unsubW,          \* [Txns \X {"u1","u2"} -> [ph |-> ..., pend |-> SUBSET Txns]]
+    \* --- scheduler-wide ---
+    active,          \* activeTransactions keys
+    graphSem,        \* graphBuilderSemaphore holder: txn id or "none"
+    version          \* var id -> commit counter (values abstracted away)
+
+txnVars    == <<status, tally, unsubs, hasDown, completedCount, inc, declared,
+                publishedInc, doublePub, droppedSpawn, snap>>
+submitVars == <<submitPc, submitMode, scanPending, curTarget, curDir, curContained>>
+schedVars  == <<active, graphSem, version>>
+vars       == <<txnVars, submitVars, exec, unsubW, schedVars>>
+
+ExecSlots  == Txns \X {"A", "B"}
+UnsubSlots == Txns \X {"u1", "u2"}
+
+NoExec  == [pc |-> "none", out |-> "none"]
+NoUnsub == [ph |-> "none", pend |-> {}]
+
+(* Exec pcs that constitute the execute/commit window *)
+ExecWindowPcs == {"regRun", "snap", "commit", "regComp", "spawnU"}
+
+---------------------------------------------------------------------------
+(* Helpers *)
+---------------------------------------------------------------------------
+
+(* execute(scheduler).start — from checkExecutionReadiness or
+   unsubscribeUpstreamDependency's zero-test. If both slots are busy a
+   third spawn is dropped — and that IS reachable before any NoDoubleExec
+   violation (a slot lingering at "resubWait" is outside the window), so
+   every spawn site records the drop in the droppedSpawn ghost and the
+   NoDroppedSpawn invariant surfaces the truncation instead of letting it
+   silently mask deeper behaviours. *)
+ExecSlotsFull(ex, t) ==
+    ex[<<t, "A">>].pc /= "none" /\ ex[<<t, "B">>].pc /= "none"
+
+UnsubSlotsFull(uw, t) ==
+    uw[<<t, "u1">>].ph /= "none" /\ uw[<<t, "u2">>].ph /= "none"
+
+SpawnExec(ex, t) ==
+    IF ex[<<t, "A">>].pc = "none"
+        THEN [ex EXCEPT ![<<t, "A">>] = [pc |-> "regRun", out |-> "none"]]
+    ELSE IF ex[<<t, "B">>].pc = "none"
+        THEN [ex EXCEPT ![<<t, "B">>] = [pc |-> "regRun", out |-> "none"]]
+    ELSE ex
+
+(* analysedTxn.triggerUnsub.start (fire-and-forget) *)
+SpawnUnsub(uw, t) ==
+    IF uw[<<t, "u1">>].ph = "none"
+        THEN [uw EXCEPT ![<<t, "u1">>] = [ph |-> "check", pend |-> {}]]
+    ELSE IF uw[<<t, "u2">>].ph = "none"
+        THEN [uw EXCEPT ![<<t, "u2">>] = [ph |-> "check", pend |-> {}]]
+    ELSE uw
+
+(* Fixed scan order (reduction R1) *)
+PickTarget(S) == CHOOSE d \in S : \A e \in S : TxnRank(d) <= TxnRank(e)
+
+---------------------------------------------------------------------------
+(* Init — reduction R4: static analysis + AnalysedTxn construction folded
+   in; every txn's submitTxn fiber is ready to run (concurrent commits). *)
+---------------------------------------------------------------------------
+
+Init ==
+    /\ status         = [t \in Txns |-> "NotScheduled"]
+    /\ tally          = [t \in Txns |-> 0]
+    /\ unsubs         = [t \in Txns |-> {}]
+    /\ hasDown        = [t \in Txns |-> FALSE]
+    /\ completedCount = [t \in Txns |-> 0]
+    /\ inc            = [t \in Txns |-> 0]
+    /\ declared       = [t \in Txns |-> Validated(DeclaredBase(t))]
+    /\ publishedInc   = [t \in Txns |-> FALSE]
+    /\ doublePub      = [t \in Txns |-> FALSE]
+    /\ droppedSpawn   = FALSE
+    /\ snap           = [s \in ExecSlots |-> [v \in VarIds |-> 0]]
+    /\ submitPc       = [t \in Txns |-> "reset1"]
+    /\ submitMode     = [t \in Txns |-> "plain"]
+    /\ scanPending    = [t \in Txns |-> {}]
+    /\ curTarget      = [t \in Txns |-> "none"]
+    /\ curDir         = [t \in Txns |-> "none"]
+    /\ curContained   = [t \in Txns |-> FALSE]
+    /\ exec           = [s \in ExecSlots |-> NoExec]
+    /\ unsubW         = [s \in UnsubSlots |-> NoUnsub]
+    /\ active         = {}
+    /\ graphSem       = "none"
+    /\ version        = [v \in VarIds |-> 0]
+
+---------------------------------------------------------------------------
+(* Submit workflow — submitTxn and
+   submitTxnForImmediateRetry. Code order is: reset tally,
+   reset hasDownstream (both OUTSIDE the semaphore), acquire, start scan
+   fibers over a snapshot of activeTransactions, set Scheduled, insert into
+   activeTransactions, JOIN the scan fibers, readiness check, release. The
+   scan loop here therefore runs AFTER setSched/insAct, exactly as the scan
+   fibers do in the code. *)
+---------------------------------------------------------------------------
+
+(* resetDependencyTally: two Ref writes, outside the
+   semaphore — they race with in-flight unsubscribe cascades, deliberately. *)
+SubmitReset1(t) ==
+    /\ submitPc[t] = "reset1"
+    /\ tally'    = [tally EXCEPT ![t] = 0]
+    /\ submitPc' = [submitPc EXCEPT ![t] = "reset2"]
+    /\ UNCHANGED <<status, unsubs, hasDown, completedCount, inc, declared,
+                   publishedInc, doublePub, droppedSpawn, snap, submitMode,
+                   scanPending, curTarget, curDir, curContained, exec,
+                   unsubW, schedVars>>
+
+SubmitReset2(t) ==
+    /\ submitPc[t] = "reset2"
+    /\ hasDown'  = [hasDown EXCEPT ![t] = FALSE]
+    /\ submitPc' = [submitPc EXCEPT ![t] = "acq"]
+    /\ UNCHANGED <<status, tally, unsubs, completedCount, inc, declared,
+                   publishedInc, doublePub, droppedSpawn, snap, submitMode,
+                   scanPending, curTarget, curDir, curContained, exec,
+                   unsubW, schedVars>>
+
+(* graphBuilderSemaphore.permit acquire + activeTransactions.values snapshot
+   (the snapshot is taken before this txn is inserted, so the
+   scan never sees self). active cannot change while the semaphore is held. *)
+SubmitAcquire(t) ==
+    /\ submitPc[t] = "acq"
+    /\ graphSem = "none"
+    /\ graphSem'    = t
+    /\ scanPending' = [scanPending EXCEPT ![t] = active]
+    /\ submitPc'    = [submitPc EXCEPT ![t] = "setSched"]
+    /\ UNCHANGED <<txnVars, submitMode, curTarget, curDir, curContained,
+                   exec, unsubW, active, version>>
+
+(* executionStatus.set(Scheduled) *)
+SubmitSetScheduled(t) ==
+    /\ submitPc[t] = "setSched"
+    /\ status'   = [status EXCEPT ![t] = "Scheduled"]
+    /\ submitPc' = [submitPc EXCEPT ![t] = "insAct"]
+    /\ UNCHANGED <<tally, unsubs, hasDown, completedCount, inc, declared,
+                   publishedInc, doublePub, droppedSpawn, snap, submitMode,
+                   scanPending, curTarget, curDir, curContained, exec,
+                   unsubW, schedVars>>
+
+(* activeTransactions.addOne *)
+SubmitInsertActive(t) ==
+    /\ submitPc[t] = "insAct"
+    /\ active'   = active \cup {t}
+    /\ submitPc' = [submitPc EXCEPT ![t] = "scanPick"]
+    /\ UNCHANGED <<txnVars, submitMode, scanPending, curTarget, curDir,
+                   curContained, exec, unsubW, graphSem, version>>
+
+(* Scan loop head; empty pending = all scan fibers joined (joinWithNever) *)
+SubmitScanPick(t) ==
+    /\ submitPc[t] = "scanPick"
+    /\ IF scanPending[t] = {}
+       THEN /\ submitPc'  = [submitPc EXCEPT ![t] = "ready"]
+            /\ UNCHANGED <<scanPending, curTarget>>
+       ELSE /\ curTarget'   = [curTarget EXCEPT ![t] = PickTarget(scanPending[t])]
+            /\ scanPending' = [scanPending EXCEPT ![t] = @ \ {PickTarget(scanPending[t])}]
+            /\ submitPc'    = [submitPc EXCEPT ![t] = "scanCheck"]
+    /\ UNCHANGED <<txnVars, submitMode, curDir, curContained, exec, unsubW,
+                   schedVars>>
+
+(* Per-target compatibility/status dispatch.
+   plain (submitTxn): incompatible -> target.subscribeDownstreamDependency(me).
+   imm (submitTxnForImmediateRetry): status Running -> as plain; status Scheduled ->
+   me.subscribeDownstreamDependency(target) — the REVERSED edge; the status
+   read is stable while the semaphore is held (registerRunning also takes
+   it), so reading and branching in one step is sound. *)
+SubmitScanCheck(t) ==
+    /\ submitPc[t] = "scanCheck"
+    /\ LET a      == curTarget[t]
+           compat == IsCompatible(declared[t], declared[a])
+       IN IF submitMode[t] = "plain"
+          THEN IF compat
+               THEN /\ submitPc' = [submitPc EXCEPT ![t] = "scanPick"]
+                    /\ UNCHANGED curDir
+               ELSE /\ curDir'   = [curDir EXCEPT ![t] = "down"]
+                    /\ submitPc' = [submitPc EXCEPT ![t] = "subCheck"]
+          ELSE CASE status[a] = "Running" /\ ~compat ->
+                        /\ curDir'   = [curDir EXCEPT ![t] = "down"]
+                        /\ submitPc' = [submitPc EXCEPT ![t] = "subCheck"]
+                 [] status[a] = "Scheduled" /\ ~compat ->
+                        /\ curDir'   = [curDir EXCEPT ![t] = "up"]
+                        /\ submitPc' = [submitPc EXCEPT ![t] = "subCheck"]
+                 [] OTHER ->
+                        /\ submitPc' = [submitPc EXCEPT ![t] = "scanPick"]
+                        /\ UNCHANGED curDir
+    /\ UNCHANGED <<txnVars, submitMode, scanPending, curTarget, curContained,
+                   exec, unsubW, schedVars>>
+
+(* subscribeDownstreamDependency's contains-check — its OWN step:
+   the gap between this read and the apply below is where H4's staleness
+   lives. down: unsubs[target] ∋ me; up: unsubs[me] ∋ target. *)
+SubmitSubCheck(t) ==
+    /\ submitPc[t] = "subCheck"
+    /\ LET a == curTarget[t]
+       IN curContained' = [curContained EXCEPT ![t] =
+                              IF curDir[t] = "down" THEN t \in unsubs[a]
+                                                    ELSE a \in unsubs[t]]
+    /\ submitPc' = [submitPc EXCEPT ![t] = "subApply"]
+    /\ UNCHANGED <<status, tally, unsubs, hasDown, completedCount, inc,
+                   declared, publishedInc, doublePub, droppedSpawn, snap,
+                   submitMode, scanPending, curTarget, curDir, exec, unsubW,
+                   schedVars>>
+
+(* The subscribe triple, reduction R2: upstream-tally increment
+   (subscribeUpstreamDependency) + unsubSpecs insert + hasDownstream set.
+   Skipped entirely if the contains-check said the edge already exists —
+   even when that check was stale (H4). *)
+SubmitSubApply(t) ==
+    /\ submitPc[t] = "subApply"
+    /\ LET a == curTarget[t]
+       IN IF curContained[t]
+          THEN UNCHANGED <<tally, unsubs, hasDown>>
+          ELSE IF curDir[t] = "down"
+               THEN /\ tally'   = [tally EXCEPT ![t] = @ + 1]
+                    /\ unsubs'  = [unsubs EXCEPT ![a] = @ \cup {t}]
+                    /\ hasDown' = [hasDown EXCEPT ![a] = TRUE]
+               ELSE /\ tally'   = [tally EXCEPT ![curTarget[t]] = @ + 1]
+                    /\ unsubs'  = [unsubs EXCEPT ![t] = @ \cup {a}]
+                    /\ hasDown' = [hasDown EXCEPT ![t] = TRUE]
+    /\ submitPc' = [submitPc EXCEPT ![t] = "scanPick"]
+    /\ UNCHANGED <<status, completedCount, inc, declared, publishedInc,
+                   doublePub, droppedSpawn, snap, submitMode, scanPending,
+                   curTarget, curDir, curContained, exec, unsubW, schedVars>>
+
+(* checkExecutionReadiness: tally read + spawn,
+   still inside the region *)
+SubmitReadiness(t) ==
+    /\ submitPc[t] = "ready"
+    /\ exec' = IF tally[t] = 0 THEN SpawnExec(exec, t) ELSE exec
+    /\ droppedSpawn' = (droppedSpawn \/ (tally[t] = 0 /\ ExecSlotsFull(exec, t)))
+    /\ submitPc' = [submitPc EXCEPT ![t] = "rel"]
+    /\ UNCHANGED <<status, tally, unsubs, hasDown, completedCount, inc,
+                   declared, publishedInc, doublePub, snap, submitMode,
+                   scanPending, curTarget, curDir, curContained, unsubW,
+                   schedVars>>
+
+(* permit release; checkRetryQueue is a no-op in Phase 1 —
+   the retry map is empty by construction *)
+SubmitRelease(t) ==
+    /\ submitPc[t] = "rel"
+    /\ graphSem = t
+    /\ graphSem'  = "none"
+    /\ submitPc'  = [submitPc EXCEPT ![t] = "idle"]
+    /\ curTarget' = [curTarget EXCEPT ![t] = "none"]
+    /\ UNCHANGED <<txnVars, submitMode, scanPending, curDir, curContained,
+                   exec, unsubW, active, version>>
+
+(* The submit wrapper's handleErrorWith (TxnRuntime.commit): an exception
+   anywhere in a PLAIN submission completes the signal with the error and
+   does nothing else — the txn stays wherever the partial workflow left it
+   (possibly a zombie in activeTransactions). For an IMM submission the
+   exception propagates into execute's dispatch instead — modelled at the
+   exec fiber (ExecResubAbort below). permit.use releases on error. *)
+SubmitAbort(t) ==
+    /\ AbortsEnabled
+    /\ submitMode[t] = "plain"
+    /\ submitPc[t] \notin {"idle"}
+    /\ graphSem' = IF graphSem = t THEN "none" ELSE graphSem
+    /\ submitPc' = [submitPc EXCEPT ![t] = "idle"]
+    /\ completedCount' = [completedCount EXCEPT ![t] = @ + 1]
+    /\ UNCHANGED <<status, tally, unsubs, hasDown, inc, declared,
+                   publishedInc, doublePub, droppedSpawn, snap, submitMode,
+                   scanPending, curTarget, curDir, curContained, exec,
+                   unsubW, active, version>>
+
+---------------------------------------------------------------------------
+(* Execute fibers — execute with the atomic-commit
+   abstraction (plan §3). *)
+---------------------------------------------------------------------------
+
+(* registerRunning: semaphore-guarded single set,
+   reduction R3. NOTE the code re-checks nothing here — no tally guard, no
+   status guard. *)
+ExecRegRunning(t, s) ==
+    /\ exec[<<t, s>>].pc = "regRun"
+    /\ graphSem = "none"
+    /\ status' = [status EXCEPT ![t] = "Running"]
+    /\ exec'   = [exec EXCEPT ![<<t, s>>].pc = "snap"]
+    /\ UNCHANGED <<tally, unsubs, hasDown, completedCount, inc, declared,
+                   publishedInc, doublePub, droppedSpawn, snap, submitVars,
+                   unsubW, schedVars>>
+
+(* Log construction abstracted to one snapshot of the footprint's versions,
+   PER FIBER — each execute run builds a private log in the code, so
+   concurrent fibers of one txn capture independent initial values. Spec A
+   refines read-time granularity; Spec B needs the snapshot only to make
+   the dirty outcome truthful. *)
+ExecSnapshot(t, s) ==
+    /\ exec[<<t, s>>].pc = "snap"
+    /\ snap' = [snap EXCEPT ![<<t, s>>] = [v \in VarIds |-> version[v]]]
+    /\ exec' = [exec EXCEPT ![<<t, s>>].pc = "commit"]
+    /\ UNCHANGED <<status, tally, unsubs, hasDown, completedCount, inc,
+                   declared, publishedInc, doublePub, droppedSpawn,
+                   submitVars, unsubW, schedVars>>
+
+(* The atomic commit: dirty iff a written var moved since the snapshot
+   (models the commit pipeline withLock{isDirty}/commit, at
+   Spec B's granularity). Publish = bump every written var. *)
+ExecCommit(t, s) ==
+    /\ exec[<<t, s>>].pc = "commit"
+    /\ LET dirtyNow == \E v \in Writes(t) : version[v] /= snap[<<t, s>>][v]
+       IN IF dirtyNow
+          THEN /\ exec' = [exec EXCEPT ![<<t, s>>] =
+                              [pc |-> "regComp", out |-> "dirty"]]
+               /\ UNCHANGED <<version, publishedInc, doublePub>>
+          ELSE /\ version' = [v \in VarIds |->
+                                IF v \in Writes(t) THEN version[v] + 1
+                                                   ELSE version[v]]
+               /\ doublePub' = [doublePub EXCEPT ![t] = @ \/ publishedInc[t]]
+               /\ publishedInc' = [publishedInc EXCEPT ![t] = TRUE]
+               /\ exec' = [exec EXCEPT ![<<t, s>>] =
+                              [pc |-> "regComp", out |-> "success"]]
+    /\ UNCHANGED <<status, tally, unsubs, hasDown, completedCount, inc,
+                   declared, droppedSpawn, snap, submitVars, unsubW, active,
+                   graphSem>>
+
+(* Commit throws before publishing — poll(commit) raises, execute's
+   handleErrorWith takes over: registerCompletion (first time) + complete.
+   This same shape also covers the NORMAL TxnResultFailure dispatch (a
+   TxnLogError log): one removal, one cascade, one Left completion. *)
+ExecCommitFail(t, s) ==
+    /\ AbortsEnabled
+    /\ exec[<<t, s>>].pc = "commit"
+    /\ exec' = [exec EXCEPT ![<<t, s>>] = [pc |-> "eRegComp", out |-> "fail"]]
+    /\ UNCHANGED <<txnVars, submitVars, unsubW, schedVars>>
+
+(* registerCompletion: semaphore-guarded remove (R3)... *)
+ExecRegComplete(t, s) ==
+    /\ exec[<<t, s>>].pc = "regComp"
+    /\ graphSem = "none"
+    /\ active' = active \ {t}
+    /\ exec'   = [exec EXCEPT ![<<t, s>>].pc = "spawnU"]
+    /\ UNCHANGED <<txnVars, submitVars, unsubW, graphSem, version>>
+
+(* ...followed by triggerUnsub.start (fire-and-forget) — fire-and-forget: the
+   cascade races everything that follows, including the dirty resubmission. *)
+ExecSpawnUnsub(t, s) ==
+    /\ exec[<<t, s>>].pc = "spawnU"
+    /\ unsubW' = SpawnUnsub(unsubW, t)
+    /\ droppedSpawn' = (droppedSpawn \/ UnsubSlotsFull(unsubW, t))
+    /\ exec' = [exec EXCEPT ![<<t, s>>].pc =
+                   IF exec[<<t, s>>].out = "success" THEN "complete"
+                                                     ELSE "resubInit"]
+    /\ UNCHANGED <<status, tally, unsubs, hasDown, completedCount, inc,
+                   declared, publishedInc, doublePub, snap, submitVars,
+                   active, graphSem, version>>
+
+(* completionSignal.complete(Right) — TxnResultSuccess dispatch. The code
+   never demotes executionStatus (nothing writes it after Running except a
+   resubmission's set(Scheduled)), so status is deliberately NOT touched
+   here; completion is tracked by completedCount alone. *)
+ExecComplete(t, s) ==
+    /\ exec[<<t, s>>].pc = "complete"
+    /\ completedCount' = [completedCount EXCEPT ![t] = @ + 1]
+    /\ exec'   = [exec EXCEPT ![<<t, s>>] = NoExec]
+    /\ UNCHANGED <<status, tally, unsubs, hasDown, inc, declared,
+                   publishedInc, doublePub, droppedSpawn, snap, submitVars,
+                   unsubW, schedVars>>
+
+(* TxnResultLogDirty dispatch: refine the declared footprint to the actual
+   one (log-derived, getValidated) and resubmit via
+   submitTxnForImmediateRetry — INSIDE this fiber. this.copy shares
+   unsubs/tally/hasDown/completionSignal; only the footprint is replaced.
+
+   REDUCTION R5 (unjustified serialization — accepted for Phase 1, rework
+   with Phase 2): the code runs each dirty fiber's resubmission inline, so
+   two dirty fibers of one txn can run two CONCURRENT imm submissions with
+   racing resets and scans. This model has one submit workflow per txn
+   (guard: submitPc = "idle"), which serializes them. The region only
+   exists after a NoDoubleExec violation; traces from enumeration runs in
+   that region must be re-validated against the code individually. *)
+ExecResubInit(t, s) ==
+    /\ exec[<<t, s>>].pc = "resubInit"
+    /\ inc[t] < MaxInc
+    /\ submitPc[t] = "idle"
+    /\ declared'     = [declared EXCEPT ![t] = Validated(ActualFP(t))]
+    /\ inc'          = [inc EXCEPT ![t] = @ + 1]
+    /\ publishedInc' = [publishedInc EXCEPT ![t] = FALSE]
+    /\ submitPc'     = [submitPc EXCEPT ![t] = "reset1"]
+    /\ submitMode'   = [submitMode EXCEPT ![t] = "imm"]
+    \* status stays "Running": the copy shares the executionStatus Ref and
+    \* nothing writes it until the resubmission's set(Scheduled) —
+    \* scanners in this window see Running and take the Running branch.
+    /\ exec'         = [exec EXCEPT ![<<t, s>>].pc = "resubWait"]
+    /\ UNCHANGED <<status, tally, unsubs, hasDown, completedCount, doublePub,
+                   droppedSpawn, snap, scanPending, curTarget, curDir,
+                   curContained, unsubW, schedVars>>
+
+(* A dirty fiber at the incarnation bound retires its slot: the code would
+   resubmit unboundedly; the model truncates the behaviour here and frees
+   the slot (leaving it pinned would compound the two-slot masking that
+   droppedSpawn guards against). Safety-only truncation, documented in the
+   README sweeps section. *)
+ExecResubTruncate(t, s) ==
+    /\ exec[<<t, s>>].pc = "resubInit"
+    /\ inc[t] >= MaxInc
+    /\ exec' = [exec EXCEPT ![<<t, s>>] = NoExec]
+    /\ UNCHANGED <<txnVars, submitVars, unsubW, schedVars>>
+
+(* The imm submission ran to completion inside this fiber; execute returns. *)
+ExecResubDone(t, s) ==
+    /\ exec[<<t, s>>].pc = "resubWait"
+    /\ submitPc[t] = "idle"
+    /\ submitMode[t] = "imm"
+    /\ exec' = [exec EXCEPT ![<<t, s>>] = NoExec]
+    /\ UNCHANGED <<txnVars, submitVars, unsubW, schedVars>>
+
+(* An exception inside the imm submission propagates to execute's
+   handleErrorWith: registerCompletion runs a SECOND time
+   and a SECOND triggerUnsub cascade is spawned over the SAME shared
+   unsubSpecs. permit.use releases the semaphore on the way out. *)
+ExecResubAbort(t, s) ==
+    /\ AbortsEnabled
+    /\ exec[<<t, s>>].pc = "resubWait"
+    /\ submitPc[t] /= "idle"
+    /\ graphSem' = IF graphSem = t THEN "none" ELSE graphSem
+    /\ submitPc' = [submitPc EXCEPT ![t] = "idle"]
+    /\ exec'     = [exec EXCEPT ![<<t, s>>] = [pc |-> "eRegComp", out |-> "fail"]]
+    /\ UNCHANGED <<txnVars, submitMode, scanPending, curTarget, curDir,
+                   curContained, unsubW, active, version>>
+
+(* Error path: registerCompletion (possibly the second time — idempotent on
+   the active set, NOT on the unsub cascade), then complete(Left). *)
+ExecErrRegComplete(t, s) ==
+    /\ exec[<<t, s>>].pc = "eRegComp"
+    /\ graphSem = "none"
+    /\ active' = active \ {t}
+    /\ exec'   = [exec EXCEPT ![<<t, s>>].pc = "eSpawnU"]
+    /\ UNCHANGED <<txnVars, submitVars, unsubW, graphSem, version>>
+
+ExecErrSpawnUnsub(t, s) ==
+    /\ exec[<<t, s>>].pc = "eSpawnU"
+    /\ unsubW' = SpawnUnsub(unsubW, t)
+    /\ droppedSpawn' = (droppedSpawn \/ UnsubSlotsFull(unsubW, t))
+    /\ exec' = [exec EXCEPT ![<<t, s>>].pc = "eComplete"]
+    /\ UNCHANGED <<status, tally, unsubs, hasDown, completedCount, inc,
+                   declared, publishedInc, doublePub, snap, submitVars,
+                   active, graphSem, version>>
+
+ExecErrComplete(t, s) ==
+    /\ exec[<<t, s>>].pc = "eComplete"
+    /\ completedCount' = [completedCount EXCEPT ![t] = @ + 1]
+    /\ exec'   = [exec EXCEPT ![<<t, s>>] = NoExec]
+    /\ UNCHANGED <<status, tally, unsubs, hasDown, inc, declared,
+                   publishedInc, doublePub, droppedSpawn, snap, submitVars,
+                   unsubW, schedVars>>
+
+---------------------------------------------------------------------------
+(* triggerUnsub cascades — detached fibers, NO semaphore.
+   The nonEmpty check and the values snapshot are separate steps on
+   purpose: a concurrent clear() (from a double-spawned sibling) can land
+   between them. Each drained edge is unsubscribeUpstreamDependency: one
+   atomic getAndUpdate(-1) whose old==1 spawns the downstream's execute. *)
+---------------------------------------------------------------------------
+
+UnsubCheck(o, u) ==
+    /\ unsubW[<<o, u>>].ph = "check"
+    /\ IF unsubs[o] = {}
+       THEN unsubW' = [unsubW EXCEPT ![<<o, u>>] = NoUnsub]
+       ELSE unsubW' = [unsubW EXCEPT ![<<o, u>>].ph = "snapVals"]
+    /\ UNCHANGED <<txnVars, submitVars, exec, schedVars>>
+
+UnsubSnapVals(o, u) ==
+    /\ unsubW[<<o, u>>].ph = "snapVals"
+    /\ unsubW' = [unsubW EXCEPT ![<<o, u>>] = [ph |-> "drain", pend |-> unsubs[o]]]
+    /\ UNCHANGED <<txnVars, submitVars, exec, schedVars>>
+
+UnsubDrain(o, u) ==
+    /\ unsubW[<<o, u>>].ph = "drain"
+    /\ unsubW[<<o, u>>].pend /= {}
+    /\ \E d \in unsubW[<<o, u>>].pend :
+        /\ tally' = [tally EXCEPT ![d] = @ - 1]
+        /\ exec'  = IF tally[d] = 1 THEN SpawnExec(exec, d) ELSE exec
+        /\ droppedSpawn' = (droppedSpawn \/ (tally[d] = 1 /\ ExecSlotsFull(exec, d)))
+        /\ unsubW' = [unsubW EXCEPT ![<<o, u>>].pend = @ \ {d}]
+    /\ UNCHANGED <<status, unsubs, hasDown, completedCount, inc, declared,
+                   publishedInc, doublePub, snap, submitVars, schedVars>>
+
+UnsubClear(o, u) ==
+    /\ unsubW[<<o, u>>].ph = "drain"
+    /\ unsubW[<<o, u>>].pend = {}
+    /\ unsubs' = [unsubs EXCEPT ![o] = {}]
+    /\ unsubW' = [unsubW EXCEPT ![<<o, u>>] = NoUnsub]
+    /\ UNCHANGED <<status, tally, hasDown, completedCount, inc, declared,
+                   publishedInc, doublePub, droppedSpawn, snap, submitVars,
+                   exec, schedVars>>
+
+---------------------------------------------------------------------------
+(* Next *)
+---------------------------------------------------------------------------
+
+Next ==
+    \/ \E t \in Txns :
+        \/ SubmitReset1(t)     \/ SubmitReset2(t)   \/ SubmitAcquire(t)
+        \/ SubmitSetScheduled(t) \/ SubmitInsertActive(t)
+        \/ SubmitScanPick(t)   \/ SubmitScanCheck(t)
+        \/ SubmitSubCheck(t)   \/ SubmitSubApply(t)
+        \/ SubmitReadiness(t)  \/ SubmitRelease(t)  \/ SubmitAbort(t)
+    \/ \E t \in Txns, s \in {"A", "B"} :
+        \/ ExecRegRunning(t, s) \/ ExecSnapshot(t, s) \/ ExecCommit(t, s)
+        \/ ExecCommitFail(t, s) \/ ExecRegComplete(t, s)
+        \/ ExecSpawnUnsub(t, s) \/ ExecComplete(t, s)
+        \/ ExecResubInit(t, s)  \/ ExecResubTruncate(t, s)
+        \/ ExecResubDone(t, s)  \/ ExecResubAbort(t, s)
+        \/ ExecErrRegComplete(t, s) \/ ExecErrSpawnUnsub(t, s)
+        \/ ExecErrComplete(t, s)
+    \/ \E o \in Txns, u \in {"u1", "u2"} :
+        \/ UnsubCheck(o, u) \/ UnsubSnapVals(o, u)
+        \/ UnsubDrain(o, u) \/ UnsubClear(o, u)
+
+Spec == Init /\ [][Next]_vars
+
+---------------------------------------------------------------------------
+(* State constraint (finiteness backstop; plan §5) *)
+---------------------------------------------------------------------------
+
+StateConstraint ==
+    \* inc needs no clause: ExecResubTruncate caps it at the action level.
+    /\ \A t \in Txns : tally[t] >= -2 /\ tally[t] <= 4
+    /\ \A v \in VarIds : version[v] <= MaxVer
+
+---------------------------------------------------------------------------
+(* Invariants (plan §5 property table) *)
+---------------------------------------------------------------------------
+
+TypeOK ==
+    /\ status \in [Txns -> {"NotScheduled", "Scheduled", "Running"}]
+    /\ graphSem \in Txns \cup {"none"}
+    /\ active \subseteq Txns
+
+(* Tallies must never go negative: a negative tally means an unsubscribe
+   was delivered for an edge the tally no longer counts (H4 family). *)
+TallyNonNegative == \A t \in Txns : tally[t] >= 0
+
+(* Contract C — the interface property Spec A assumes (plan §3): no two
+   transactions in their execute/commit window with incompatible DECLARED
+   footprints (current incarnations). The code's window is
+   [registerRunning fired, registerCompletion fired] — status stays
+   "Running" forever in the code (nothing demotes it), so the window is
+   encoded from exec-fiber position, not status: past regRun (snapshot
+   pending or taken, commit pending) until the active-set removal fires. *)
+InExecWindow(t) ==
+    \E s \in {"A", "B"} : exec[<<t, s>>].pc \in {"snap", "commit", "regComp"}
+
+ContractC ==
+    \A t \in Txns, u \in Txns :
+        (t /= u /\ InExecWindow(t) /\ InExecWindow(u))
+            => IsCompatible(declared[t], declared[u])
+
+(* No transaction has two fibers inside the execute/commit window at once
+   (double-spawn via stale zero-tests / stale subscriptions). *)
+NoDoubleExec ==
+    \A t \in Txns :
+        ~(exec[<<t, "A">>].pc \in ExecWindowPcs /\ exec[<<t, "B">>].pc \in ExecWindowPcs)
+
+(* An execute fiber must never start for a transaction that already
+   completed — a completed txn re-executing means its log commits twice.
+   "Completed" is completedCount >= 1 (the code never demotes status, so
+   status carries no completion information). *)
+NoExecOnCompleted ==
+    \A t \in Txns, s \in {"A", "B"} :
+        exec[<<t, s>>].pc = "regRun" => completedCount[t] = 0
+
+(* The two-slot fiber bound never silently truncated a behaviour: every
+   attempted spawn found a free slot. Include this in enumeration runs —
+   if it goes red, deeper verdicts at those depths are unreliable until
+   slots are widened for that scenario. *)
+NoDroppedSpawn == ~droppedSpawn
+
+(* completionSignal completes at most once (the #52 class) *)
+CompletionAtMostOnce == \A t \in Txns : completedCount[t] <= 1
+
+(* A transaction's writes are published at most once per incarnation *)
+NoDoublePublish == \A t \in Txns : ~doublePub[t]
+
+===============================================================================

--- a/specs/scheduler/SchedulerAborts.cfg
+++ b/specs/scheduler/SchedulerAborts.cfg
@@ -1,0 +1,26 @@
+\* Spec B robustness config: nondeterministic failure injection ON.
+\* Models "an exception lands anywhere handleErrorWith can see it"
+\* (execute's handleErrorWith and the submit wrapper in TxnRuntime.commit) — the model does not claim any
+\* particular throw is organically reachable, only that IF one lands, the
+\* completion/unsub bookkeeping behaves as checked. Run with -deadlock.
+\*
+\* MEASURED (2026-07-11): CompletionAtMostOnce violated at depth 16 — a
+\* submit-wrapper abort AFTER the readiness check completes the signal with
+\* an error while the already-spawned execute commits and completes again:
+\* the caller is told "failed" for a transaction that published. Run
+\* manually or via the workflow_dispatch-gated step in specs.yml (pinned
+\* expectation: CompletionAtMostOnce — the shallowest violation by a wide
+\* margin, so the pin is stable). Mid-publish throws are inside the
+\* atomic-commit abstraction and NOT covered here (Spec A territory).
+\* See specs/README.md.
+CONSTANT
+    NoParent = NoParent
+    MaxInc = 2
+    MaxVer = 6
+    AbortsEnabled = TRUE
+SPECIFICATION Spec
+CONSTRAINT StateConstraint
+INVARIANT TypeOK
+INVARIANT TallyNonNegative
+INVARIANT CompletionAtMostOnce
+INVARIANT NoDoublePublish

--- a/specs/verify_anchors.sh
+++ b/specs/verify_anchors.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Verify that every TLA+ invariant listed in specs/README.md has a matching
+# `// SPEC: <InvariantName>` anchor in the declared source file.
+#
+# Parses the Invariant Cross-Reference tables, extracts (invariant, file) pairs,
+# and greps for `SPEC: <invariant>` in the declared file.
+#
+# Ported from ../echidna/specs/verify_anchors.sh (identical mechanism; Scala
+# sources use the same `//` comment syntax and live under src/, so both the
+# anchor grep and the path regex carry over unchanged).
+#
+# Exits non-zero if any anchor is missing. Run from the repository root.
+
+set -euo pipefail
+
+README="specs/README.md"
+
+if [[ ! -f "$README" ]]; then
+  echo "error: $README not found — run from the repository root." >&2
+  exit 2
+fi
+
+# Extract rows of the form:
+#   | `InvariantName` | `src/path/to/file.scala` | description |
+# from the cross-reference tables. The first column is the invariant, the
+# second is the source file carrying the anchor.
+rows=$(awk '
+  /^### .* \(anchors in / { in_table = 1; next }
+  /^## / { in_table = 0 }
+  in_table && /^\| *`[A-Za-z_][A-Za-z0-9_]*` *\| *`src\// {
+    line = $0
+    # Invariant is the first backticked token.
+    match(line, /`[A-Za-z_][A-Za-z0-9_]*`/)
+    inv = substr(line, RSTART + 1, RLENGTH - 2)
+    # Source path: first backticked token starting with src/.
+    rest = substr(line, RSTART + RLENGTH)
+    match(rest, /`src\/[^`]+`/)
+    path = substr(rest, RSTART + 1, RLENGTH - 2)
+    print inv "\t" path
+  }
+' "$README")
+
+if [[ -z "$rows" ]]; then
+  echo "error: no invariant rows parsed from $README" >&2
+  echo "hint: table rows must match | \`Invariant\` | \`src/...\` | ... |" >&2
+  exit 2
+fi
+
+missing=0
+checked=0
+
+while IFS=$'\t' read -r invariant path; do
+  [[ -z "$invariant" ]] && continue
+  checked=$((checked + 1))
+  if [[ ! -f "$path" ]]; then
+    echo "MISSING: $invariant — declared source file $path does not exist" >&2
+    missing=$((missing + 1))
+    continue
+  fi
+  # Match `// SPEC: <Invariant>` followed by end-of-line, space, or non-alphanumeric —
+  # prevents `TallyNonNegative` from matching an anchor named `Tally`.
+  if ! grep -Eq "// SPEC: ${invariant}([^A-Za-z0-9_]|$)" "$path"; then
+    echo "MISSING: $invariant — no \`// SPEC: ${invariant}\` anchor in $path" >&2
+    missing=$((missing + 1))
+  fi
+done <<< "$rows"
+
+if [[ $missing -gt 0 ]]; then
+  echo ""
+  echo "anchor verification failed: $missing missing of $checked declared"
+  echo "fix: add \`// SPEC: <InvariantName>\` next to the relevant code,"
+  echo "     or update specs/README.md if the invariant moved to a different file."
+  exit 1
+fi
+
+# Reverse pass: every `// SPEC: <Name>` anchor in the source tree must appear
+# as a PARSED row above. This closes both fail-open directions: an orphaned
+# or renamed anchor is flagged here, and a README row that silently fell out
+# of the awk parse (malformed backticks/path) leaves its code anchor orphaned
+# and is flagged here too.
+orphans=0
+declared_names=$(printf '%s\n' "$rows" | cut -f1)
+while IFS= read -r name; do
+  [[ -z "$name" ]] && continue
+  if ! printf '%s\n' "$declared_names" | grep -qx "$name"; then
+    echo "ORPHAN: \`// SPEC: $name\` exists in src/ but is not a parsed row in $README" >&2
+    orphans=$((orphans + 1))
+  fi
+done < <(grep -rhoE '// SPEC: [A-Za-z_][A-Za-z0-9_]*' src/ | sed 's|// SPEC: ||' | sort -u)
+
+if [[ $orphans -gt 0 ]]; then
+  echo ""
+  echo "anchor verification failed: $orphans orphaned anchor(s) in src/"
+  echo "fix: add a cross-reference row to $README, or remove/rename the anchor."
+  exit 1
+fi
+
+echo "anchor verification OK: $checked invariants mapped and found; no orphans."

--- a/src/main/scala/bengal/stm/model/runtime/IdFootprint.scala
+++ b/src/main/scala/bengal/stm/model/runtime/IdFootprint.scala
@@ -23,6 +23,13 @@ private[stm] case class IdFootprint(
   isValidated: Boolean = false
 ) {
 
+  // SPEC: LemmaValidatedIdempotent — one application of this transform is a
+  // fixpoint (FootprintLemmas.tla checks it exhaustively), which makes the
+  // isValidated short-circuit sound ON RE-APPLICATION. The flag's full
+  // soundness also needs call-site discipline: addReadId/addWriteId/mergeWith
+  // copy isValidated through unchanged, so a validated footprint that is
+  // subsequently mutated would skip re-validation (today's call sites never
+  // do that — validation happens last, in the runtime).
   private[stm] lazy val getValidated =
     if (isValidated) {
       this
@@ -49,6 +56,11 @@ private[stm] case class IdFootprint(
   private[stm] def mergeWith(idScope: IdFootprint): IdFootprint =
     this.copy(readIds = readIds ++ idScope.readIds, updatedIds = updatedIds ++ idScope.updatedIds)
 
+  // SPEC: DocumentsReadGapH5 — ids (reads included) are tested only against
+  // the OTHER side's update ids, so a child-entry WRITE is never checked
+  // against a parent-structure READ: whole-map reads are judged compatible
+  // with new-key inserts (FootprintLemmas.tla pins this; hypothesis H5 in
+  // docs/plans/formal-specs.md tracks the behavioural consequence).
   private def asymmetricCompatibleWith(input: IdFootprint): Boolean =
     combinedRawIds.intersect(input.updateRawIds).isEmpty && !combinedIds.exists(
       _.parent.exists(p => input.updateRawIds.contains(p.value))

--- a/src/main/scala/bengal/stm/runtime/TxnRuntimeContext.scala
+++ b/src/main/scala/bengal/stm/runtime/TxnRuntimeContext.scala
@@ -153,6 +153,9 @@ private[stm] trait TxnRuntimeContext[F[_]] {
         _ <- analysedTxn.resetDependencyTally
         _ <- graphBuilderSemaphore.permit.use { _ =>
                for {
+                 // SPEC: ContractC — this scan is the mechanism meant to keep
+                 // footprint-incompatible txns out of overlapping execute
+                 // windows (Scheduler.tla checks the guarantee itself).
                  testAndLink <- activeTransactions.values.toList.parTraverse { aTxn =>
                                   Async[F]
                                     .ifM(
@@ -184,6 +187,9 @@ private[stm] trait TxnRuntimeContext[F[_]] {
         _ <- analysedTxn.triggerUnsub.start
       } yield ()
 
+    // SPEC: NoExecOnCompleted — registerRunning re-checks nothing (no tally
+    // guard, no completion guard), so a stale execute spawn runs to commit;
+    // Scheduler.tla checks no execute fiber starts for a completed txn.
     def registerRunning(analysedTxn: AnalysedTxn[_]): F[Unit] =
       graphBuilderSemaphore.permit.use { _ =>
         analysedTxn.executionStatus.set(Running)
@@ -220,12 +226,18 @@ private[stm] trait TxnRuntimeContext[F[_]] {
     private[stm] val resetDependencyTally: F[Unit] =
       dependencyTally.set(0) >> hasDownstream.set(false)
 
+    // SPEC: NoDoubleExec — execute fibers are spawned here (readiness) and in
+    // unsubscribeUpstreamDependency (tally zero-test) with no dedup guard;
+    // Scheduler.tla checks that at most one fiber is ever in the commit window.
     private[stm] val checkExecutionReadiness: F[Unit] =
       Async[F].ifM(dependencyTally.get.map(_ == 0))(
         execute(scheduler).start.void,
         Async[F].unit
       )
 
+    // SPEC: TallyNonNegative — the getAndUpdate decrement below is the only
+    // tally sink; a negative tally means an unsubscribe was delivered for an
+    // edge the tally no longer counts (stale edge from a shared unsubSpecs).
     private val unsubscribeUpstreamDependency: F[Unit] =
       Async[F].ifM(dependencyTally.getAndUpdate(_ - 1).map(_ == 1))(
         execute(scheduler).start.void,
@@ -276,6 +288,9 @@ private[stm] trait TxnRuntimeContext[F[_]] {
             Async[F].delay((TxnLogError(ex), None))
         }
 
+    // SPEC: NoDoublePublish — log.commit below publishes the write set; a
+    // second concurrent execute fiber for the same txn re-runs the whole
+    // pipeline and publishes again (Scheduler.tla checks once-per-incarnation).
     private val commit: F[TxnResult] =
       for {
         logResult <- getTxnLogResult
@@ -331,6 +346,9 @@ private[stm] trait TxnRuntimeContext[F[_]] {
                (for {
                  result <- poll(commit)
                  _      <- ex.registerCompletion(this)
+                 // SPEC: CompletionAtMostOnce — completes here, in the error
+                 // handler below, and in the submit wrapper (all Deferred
+                 // first-wins); Scheduler.tla counts completions per txn.
                  _ <- result match {
                         case TxnResultSuccess(result) =>
                           completionSignal


### PR DESCRIPTION
## Summary

Phase 1 of the formal specification plan (`docs/plans/formal-specs.md`): TLA+ specs for the footprint compatibility relation and the transaction scheduler protocol, model-checked with TLC, with mechanical spec↔code alignment wired into CI. Follows the echidna house pattern (raw TLA+, per-concern configs, anchor verification, dedicated specs workflow).

- **`specs/common/Footprint.tla`** — exact encoding of `IdFootprint.isCompatibleWith`/`getValidated`, single-sourced (symlinked into consumer spec dirs). `FootprintLemmas.tla` checks the relation's algebra exhaustively over a 4-id universe (all green) and **pins the H5 read gap**: a parent-structure READ is judged compatible with a child-entry WRITE (whole-map read vs new-key insert) — the relation-level premise of the phantom-write-skew hypothesis. The pin flips red if the relation is ever fixed, forcing spec/verdict updates.
- **`specs/scheduler/Scheduler.tla`** — the scheduler protocol (submission, graph building, dependency tallies, unsubscribe cascades, dirty resubmission, error recovery) at Ref/TrieMap-operation granularity with documented reductions. **All six safety invariants fail organically** (no failure injection) — hypothesis H4 confirmed: a dirty resubmission's reversed dependency edge lands on a transaction whose execute fiber was already spawned (`registerRunning` re-checks nothing), and the previous incarnation's fire-and-forget cascade drains the new incarnation's edge from the shared `unsubSpecs`, spawning a second execute — **the transaction runs and commits twice**. Minimal 49-state trace, validated line-by-line against `TxnRuntimeContext.scala`; full narrative in `specs/README.md`. A `droppedSpawn` ghost bounds the model's own two-slot truncation (red only from search depth ~72, above all defect verdicts at 50–64).
- **Two-way pinned CI** (`.github/workflows/specs.yml`): clean specs must verify; confirmed counterexamples must keep reproducing (`specs/check_expected.sh`) — so a protocol fix forces the spec, the verdict table, and the plan to move together. `specs/verify_anchors.sh` cross-checks the 8 `// SPEC:` source anchors in both directions (missing and orphaned).
- **`specs/README.md`** is the verdict source of truth (verdict table, atomicity mapping, reduction justifications, state-space measurements); Scala changes are comment-only `// SPEC:` anchors.

Defect verdicts are documented as decision points, not presumed fixes — fix PRs are planned Phase 5 work, each required to flip its pinned expectation with a regression test.

## Test plan

- [x] `sbt +test` — 143 tests pass on Scala 2.13 and 3.3.7
- [x] `sbt scalafmtCheckAll` clean
- [x] `./specs/verify_anchors.sh` — 8 anchors mapped, no orphans
- [x] `./specs/check_expected.sh specs/common/FootprintLemmas.cfg specs/common/FootprintLemmas.tla NONE` — clean
- [x] `./specs/check_expected.sh specs/scheduler/Scheduler.cfg specs/scheduler/Scheduler.tla NoDoubleExec` — pinned counterexample reproduces
- [x] `./specs/check_expected.sh specs/scheduler/SchedulerAborts.cfg specs/scheduler/Scheduler.tla CompletionAtMostOnce` — robustness pin reproduces
- [ ] `TLA+ Specs` workflow green on this PR (runs the anchor check + both CI-tier pins)