### PR TITLE
Fix H6: check at commit that the declared footprint covers what was touched

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -126,6 +126,13 @@ jobs:
             specs/commit/CommitProtocol.tla \
             NONE
 
+      - name: Check commit protocol — H6 data-dependent footprint (expected clean since the H6 fix)
+        run: |
+          ./specs/check_expected.sh \
+            specs/commit/CommitH6.cfg \
+            specs/commit/CommitProtocol.tla \
+            NONE
+
       - name: Check commit protocol — dirty refinement (expected clean)
         run: |
           ./specs/check_expected.sh \

--- a/docs/plans/formal-specs.md
+++ b/docs/plans/formal-specs.md
@@ -38,16 +38,22 @@ so the transaction is serialized and runs alone — which makes its unvalidated
 reads trivially safe. All nine TLC expectations across the workstream are now
 expected-CLEAN; there are no pinned counterexamples left.
 
-**What the H3 fix does NOT cover, and it is the natural next hypothesis.**
-Flagging reaches only the paths where the walker *throws*. A **data-dependent
-footprint** — an access set computed from values read before submission, which
-then changed — completes without throwing, is therefore unflagged and trusted,
-and can under-declare a READ by exactly the H3 mechanism. Post-fix it is the
-ONLY remaining source of declared/actual divergence, which means it is also the
-only thing that can still drive a transaction down the dirty-resubmission path:
-that machinery now exists to service one path, and that path is unsound. Both
-`Scheduler.cfg`'s `t1` and `CommitDirty.cfg`'s `ddw` had to be re-founded on
-this realisation to stay reachable (see §10).
+**H6 — data-dependent footprints — CONFIRMED and FIXED (2026-07-12).** The hole
+the H3 fix could not reach, promoted from a §10 footnote the moment H3 landed.
+The walker runs BEFORE `submitTxn` — outside any Contract-C window — and computes
+the access set from LIVE reads, so a transaction whose keys depend on a value it
+read can be scheduled on a footprint naming the WRONG ids. Nothing throws, so
+nothing is flagged. Same mechanism as H3, same invariant.
+**Fixed by a commit-time COVERAGE check**: under the locks and *before publishing*,
+verify that the declared footprint covers what the run actually touched; if not,
+refine from the actual log and re-run. Checking before the publish is what makes
+it sound in both directions. `IdFootprint.covers` is deliberately NOT a subset
+test — a whole-map read legitimately expands into a log entry per key — and
+`LemmaCoverageIsSound` proves the real thing exhaustively over every ordered
+triple of footprints.
+
+**All six hypotheses (H1–H6) are now confirmed and fixed.** Ten TLC expectations,
+all expected-clean; no pinned counterexamples remain.
 Two results came out of Spec A besides the verdicts: **the H5 fix is what
 discharges Spec B's atomic-commit abstraction** (§3's refinement obligation),
 and **the commit protocol alone is not serializable** — removing only the
@@ -466,8 +472,8 @@ on nothing TLA-related.
   collision conflates two vars in the log map (silent entry overwrite) and in
   footprints. The specs `ASSUME` distinct IDs; the risk is documented in
   `specs/README.md` and is property-test / arithmetic territory, not TLC territory.
-- **Data-dependent footprints — PROMOTED (2026-07-11): this is now the next
-  hypothesis, not a footnote.** A txn whose access set depends on values read can
+- **Data-dependent footprints — PROMOTED (2026-07-11), then CONFIRMED and FIXED
+  as H6 (2026-07-12). Retained here as the record of how it surfaced.** A txn whose access set depends on values read can
   declare one set and touch another: the static-analysis walker runs BEFORE
   `submitTxn`, outside any Contract-C window, and the values it reads to compute
   keys can change before the transaction is scheduled. Nothing throws, so nothing
@@ -477,12 +483,20 @@ on nothing TLA-related.
   threw.
 
   The original note here said "revisit only if H3/H5 verdicts make refinement
-  soundness load-bearing." They did. Post-H3-fix this is the ONLY remaining source
-  of declared/actual divergence, and therefore the only thing that can still drive
-  the dirty-resubmission path at all: that machinery now exists to service a single
-  path, and that path is unsound. Both `Scheduler.cfg`'s `t1` and
-  `CommitDirty.cfg`'s `ddw` had to be re-founded on it to stay reachable, which is
-  the clearest possible signal that it is load-bearing.
+  soundness load-bearing." They did. Post-H3-fix this was the ONLY remaining source
+  of declared/actual divergence, and therefore the only thing that could still
+  drive the dirty-resubmission path at all: that machinery existed to service a
+  single path, and that path was unsound. Both `Scheduler.cfg`'s `t1` and
+  `CommitDirty.cfg`'s `ddw` had to be re-founded on it to stay reachable, which was
+  the clearest possible signal that it was load-bearing.
+
+  **FIXED (2026-07-12) — see the H6 row in §6.** The commit-time coverage check
+  catches it: an inaccurate declared footprint is caught at the one point where it
+  can still be caught harmlessly, before anything is published. Worth recording
+  how this arrived, because it is the pattern the whole workstream ran on — the
+  hypothesis was not found by staring at the code, it was *forced out* by a fix.
+  Closing H3 made `CommitDirty` vacuous, and asking "so what CAN still go dirty?"
+  had exactly one answer.
 - **Semaphore fairness:** CE `Semaphore` is FIFO; the model uses weak fairness, which
   is *weaker in a way that can matter* — see the fairness row in §9 for the
   validation discipline and escalation path.

--- a/specs/README.md
+++ b/specs/README.md
@@ -132,8 +132,13 @@ expected to reproduce a **pinned counterexample** (an EXPECTED-RED verdict):
 ./specs/check_expected.sh specs/commit/CommitH3Writer.cfg \
     specs/commit/CommitProtocol.tla NONE
 
-# The one case the fallback IS caught — a pure write-write collision, by the
-# commit locks plus the dirty check. EXPECTED CLEAN.
+# H6 — data-dependent footprint divergence. The declared footprint names the
+# WRONG ids because the walker computed them from a value that changed before
+# the transaction was scheduled. EXPECTED CLEAN since the H6 fix.
+./specs/check_expected.sh specs/commit/CommitH6.cfg \
+    specs/commit/CommitProtocol.tla NONE
+
+# The dirty-refinement path. EXPECTED CLEAN.
 ./specs/check_expected.sh specs/commit/CommitDirty.cfg \
     specs/commit/CommitProtocol.tla NONE
 
@@ -205,6 +210,9 @@ judgement below is **computed** by `common/Footprint.tla`, never hand-assigned.
 | `ContractCHolds` | **HOLDS** on every config — but read it as a *guard pin*, not a verified protocol property: it restates `TxnEnter`'s guard, so it goes red only if a future edit weakens the guard and silently widens the model's concurrency. It is **trivially true in fallback mode**, where the declared footprints are empty and empty is compatible with everything. The property itself is *earned* by Spec B, which checks `ContractC` against the real scheduler | all `commit/` cfgs |
 | `TypeOK`, `LocksHeldConsistent`, `BoundsNeverBind`, `PublishedExactlyOnce` | **HOLD** on every config — model sanity checks, not protocol results. `LocksHeldConsistent` earned its keep: it caught a real model bug (a release path that freed the locks but left the acquired-prefix bookkeeping stale). `PublishedExactlyOnce` is **structurally unfalsifiable here** — `pubCount` increments only in `Publish`, which is the sole exit from `validate` to `release`, and nothing re-enters. The real once-per-incarnation guarantee is Spec B's `NoDoublePublish`, which *can* fail and did, pre-H4-fix | all `commit/` cfgs |
 
+| **H6 — data-dependent footprint divergence** (`CommitSnapshotValid`) | **CONFIRMED and FIXED (2026-07-12).** The hole the H3 fix could not reach. `staticAnalysisCompiler` runs in `TxnRuntime.commit` **before** `submitTxn` — outside `activeTransactions`, outside any Contract-C window — and computes the access set from **live reads**. So a transaction whose keys or targets depend on a value it read can be scheduled on a footprint naming **the wrong ids**: read a key from a var, have a peer change that var in the gap before scheduling, and the run touches an entry nobody declared. **Nothing throws**, so the H3 flag never fires and the scheduler simply trusts it. Same mechanism as H3, same invariant — an inaccurate declared footprint is an inaccurate declared footprint, whether it got that way by throwing or by racing. **FIXED**: a commit-time **coverage check**. Under the locks and *before publishing*, ask whether the declared footprint COVERS what the run actually touched; if not, refine from the actual log and re-run. Checking before the publish is what makes it work in both directions — our undeclared write never lands, so a peer's unvalidated read of it stays valid, and our own undeclared read never reaches a caller | `CommitH6.cfg` (CI, expected clean) |
+| **Coverage is not a subset test** | `IdFootprint.covers` asks whether declaring one footprint excludes at least as much concurrency as declaring another would. A subset test on raw ids would be **unusable**: a whole-map read legitimately expands, in the log, into a read-only entry for *every existing key*, so the actual footprint properly contains ids the walker never named — and a subset test would abort every whole-map read in the library. Those ids *are* covered, because a parent read conflicts with any child write via the relation's third conjunct. Note the asymmetry: a parent **read** covers a child **read**, but only a parent **write** covers a child **write**. `LemmaCoverageIsSound` checks the whole thing exhaustively over every ordered *triple* of footprints — it is proven, not argued | `FootprintLemmas.cfg` |
+
 **The central design fact, now machine-checked.** Removing *only* the Contract C
 guard — accurate footprints, the H5-fixed relation, and every lock and dirty
 check left intact — makes `CommitSnapshotValid` fail (negative control NC-4).
@@ -272,6 +280,8 @@ fixes are pre-validated against the model before a line of Scala moves.
 | # | Break / fix applied | Result |
 |---|---------------------|--------|
 | NC-1 | **Revert the H2 fix**: sort by the **log key** again instead of the lock's owner id | `CommitH2.cfg` goes **red** (`NoWaitsForCycle`) — the model still detects H2, so the post-fix clean verdict means the fix works rather than that the model stopped looking |
+| NC-6 | Remove the commit-time coverage check | `CommitH6.cfg` goes **red** (`CommitSnapshotValid`) — the model still detects H6 |
+| NC-7 | Break `Covers` so a declared write "covers" a **sibling** entry of the same map (H6's exact mechanism) | `LemmaCoverageIsSound` **fails** — the lemma specifically rejects H6, rather than being satisfiable by any plausible-looking definition |
 | NC-5 | Remove `withLock`'s `.distinct` | `CommitH2.cfg` **deadlocks** — `dbl`'s two fresh keys in one map alias to that map's single lock, and taking a 1-permit `Semaphore` twice self-deadlocks. Pins the dedup, which the H2 fix changed |
 | NC-2 | **Revert the H3 fix**: drop the `~f.under /\ ~g.under` clause from `IsCompatible` | All three H3 configs go **red** again (`CommitSnapshotValid`) — the model still detects H3, so the post-fix clean verdicts mean the fix works rather than that the model stopped looking. This control also predicted, *before the fix existed*, that it would make `CommitDirty`'s refinement path unreachable, which is why that config was rebuilt around `ddw` |
 | NC-3 | Remove the relation's **third conjunct** (the pre-H5-fix relation) | `CommitAccurate.cfg` goes **red** (`CommitSnapshotValid`) — the H5 fix is load-bearing here, confirmed from the commit-protocol side |

--- a/specs/commit/CommitH6.cfg
+++ b/specs/commit/CommitH6.cfg
@@ -1,0 +1,44 @@
+\* Spec A — H6: DATA-DEPENDENT FOOTPRINT DIVERGENCE.
+\*
+\* The hole the H3 fix cannot reach, and the last one standing.
+\*
+\* staticAnalysisCompiler runs in TxnRuntime.commit BEFORE submitTxn — outside
+\* activeTransactions, outside any Contract-C window — and it computes the access
+\* set by executing LIVE READS. So a transaction whose keys or targets depend on a
+\* value it read can be scheduled on a footprint that names THE WRONG IDS:
+\*
+\*     for { k <- keyVar.get          \* analysis reads keyVar = "a"
+\*           _ <- myMap.set(k, 1) }   \* so it DECLARES a write to entry (myMap,"a")
+\*
+\* Another transaction commits keyVar := "b" in the gap between the analysis and
+\* the scheduling window. The real log run — now inside the window — reads "b" and
+\* writes entry (myMap,"b"), an id the scheduler never knew about.
+\*
+\* NOTHING THREW. The walker completed, so the footprint is not flagged, and the
+\* H3 fix does not apply. The scheduler trusts a footprint that is simply wrong.
+\*
+\* Scenario: ddw declares a write to y but really writes x (StaticFP vs ActualFP).
+\* ro reads x, accurately declared. Their DECLARED footprints are disjoint, so
+\* Contract C lets them overlap — and then ddw publishes x underneath ro's read.
+\* ro holds no lock on x and never validates it (read-only entries are never
+\* commit-validated), so it commits on a value that no longer exists.
+\*
+\* EXPECTED RED: CommitSnapshotValid — the same invariant, and the same mechanism,
+\* as H3. An inaccurate declared footprint is an inaccurate declared footprint,
+\* whether it got that way by throwing or by racing.
+CONSTANT
+    NoParent = NoParent
+    Txns = {"ddw", "ro"}
+    UnderDeclared = {}
+    MaxInc = 2
+SPECIFICATION Spec
+CONSTRAINT StateConstraint
+INVARIANT TypeOK
+INVARIANT ContractCHolds
+INVARIANT LocksHeldConsistent
+INVARIANT LockOwnerStable
+INVARIANT NoLocksWithoutWrites
+INVARIANT PublishedExactlyOnce
+INVARIANT NoWaitsForCycle
+INVARIANT BoundsNeverBind
+INVARIANT CommitSnapshotValid

--- a/specs/commit/CommitProtocol.tla
+++ b/specs/commit/CommitProtocol.tla
@@ -539,6 +539,32 @@ EntryDirty(t, e) ==
 
 IsDirty(t) == \E e \in Writes(t) : EntryDirty(t, e)
 
+(* THE H6 FIX — the commit-time coverage check.
+   The scheduler placed this transaction using its DECLARED footprint. Under the
+   locks, before publishing anything, ask whether that footprint actually COVERS
+   what the run really touched. If it does, Contract C on the declared footprint
+   implies Contract C on the actual one (LemmaCoverageIsSound, checked
+   exhaustively over every footprint triple) and the scheduling was sound. If it
+   does not, the transaction was placed on a footprint that did not describe it —
+   so it must ABORT WITHOUT PUBLISHING and re-run with the refined footprint,
+   exactly as the dirty path does.
+
+   Aborting before the publish is what makes this work in BOTH directions: our
+   undeclared write never lands, so a peer's unvalidated read of it stays valid;
+   and our own undeclared read never reaches a caller.
+
+   An UNDER-APPROXIMATED footprint skips the check: it is incompatible with
+   everything (the H3 fix), so the transaction ran alone, nothing could change
+   under it, and its reads are valid whatever it touched. Checking coverage there
+   would abort it every time for no gain. *)
+CoverageOk(t) ==
+    \/ declared[t].under
+    \/ Covers(declared[t], Validated(ActualFP(t)))
+
+(* Either failure sends the transaction down the same road: release, refine from
+   the actual log, re-run. *)
+NeedsRefinement(t) == IsDirty(t) \/ ~CoverageOk(t)
+
 (* A structure read observes the whole K -> V map (TxnVarMap.get), so any
    write to any child bumps the structure's version. *)
 BumpedBy(t, e) ==
@@ -713,7 +739,7 @@ AcquireDone(t) ==
    are not visible in txnVarMap.get). *)
 Publish(t) ==
     /\ pc[t] = "validate"
-    /\ ~IsDirty(t)
+    /\ ~NeedsRefinement(t)
     /\ readValid' = [readValid EXCEPT ![t] =
                         IF ReadsStillValid(t) THEN "ok" ELSE "bad"]
     /\ version'   = [e \in Entities |->
@@ -732,7 +758,7 @@ Publish(t) ==
    is all isDirty looks at. *)
 DirtyRestart(t) ==
     /\ pc[t] = "validate"
-    /\ IsDirty(t)
+    /\ NeedsRefinement(t)
     /\ inc[t] < MaxInc
     /\ lockHolder' = [l \in Locks |->
                         IF lockHolder[l] = t THEN "none" ELSE lockHolder[l]]
@@ -756,7 +782,7 @@ DirtyRestart(t) ==
    verdict (BoundsNeverBind). *)
 DirtyTruncate(t) ==
     /\ pc[t] = "validate"
-    /\ IsDirty(t)
+    /\ NeedsRefinement(t)
     /\ inc[t] = MaxInc
     /\ lockHolder' = [l \in Locks |->
                         IF lockHolder[l] = t THEN "none" ELSE lockHolder[l]]

--- a/specs/common/Footprint.tla
+++ b/specs/common/Footprint.tla
@@ -96,6 +96,39 @@ IsCompatible(f, g) ==
     /\ AsymCompat(f, g)
     /\ AsymCompat(g, f)
 
+(*****************************************************************************)
+(* COVERAGE — the H6 fix.                                                    *)
+(*                                                                           *)
+(* The DECLARED footprint (what the scheduler saw) COVERS the ACTUAL one     *)
+(* (what the log really touched) iff declaring the former excludes at least  *)
+(* as much concurrency as declaring the latter would have. If that holds,    *)
+(* Contract C on the declared footprint implies Contract C on the actual     *)
+(* one, and the transaction's scheduling was sound after all.                *)
+(*                                                                           *)
+(* NOT a subset test on raw ids. That would be BOTH unsound and unusable:    *)
+(*                                                                           *)
+(*   - unusable, because a whole-map READ legitimately produces a read-only  *)
+(*     log entry for EVERY existing key (TxnLogValid.getVarMap), so the      *)
+(*     actual footprint properly contains ids the static footprint never     *)
+(*     named. Those ids ARE covered — a parent-structure read conflicts with *)
+(*     any child write via the relation's third conjunct — and a subset test *)
+(*     would abort every whole-map read in the library.                      *)
+(*   - and it would still miss the hierarchy: an id is covered if the        *)
+(*     footprint names it OR names its PARENT, but a parent READ covers a    *)
+(*     child READ while only a parent WRITE covers a child WRITE.            *)
+(*                                                                           *)
+(* LemmaCoverageIsSound (FootprintLemmas.tla) checks the whole thing         *)
+(* exhaustively against the relation, over every ordered TRIPLE of           *)
+(* footprints, rather than trusting the argument above.                      *)
+(*****************************************************************************)
+Covers(declared, actual) ==
+    /\ \A id \in actual.reads :
+            \/ id.val \in CombinedRawIds(declared)
+            \/ (id.par /= NoParent /\ id.par \in CombinedRawIds(declared))
+    /\ \A id \in actual.updates :
+            \/ id.val \in UpdateRawIds(declared)
+            \/ (id.par /= NoParent /\ id.par \in UpdateRawIds(declared))
+
 (*
  * getValidated:
  *   readIds := (readIds -- updatedIds)

--- a/specs/common/FootprintLemmas.tla
+++ b/specs/common/FootprintLemmas.tla
@@ -48,6 +48,20 @@ Ids == {PV1, S, E1, E2}
    untrustworthy footprints — 512 footprints, 262,144 ordered pairs. *)
 Footprints == [reads : SUBSET Ids, updates : SUBSET Ids, under : BOOLEAN]
 
+(* The COMPLETE footprints — those the walker fully determined. The coverage
+   lemma quantifies `declared` and `actual` over these rather than over the whole
+   universe, and that is exact rather than a shortcut: an under-approximated
+   footprint is incompatible with everything
+   (LemmaUnderApproximatedIncompatibleWithAll), so a triple with an
+   under-approximated `declared` discharges vacuously, and `actual` is a log
+   footprint, which is complete by construction. `g` likewise: if it is
+   under-approximated then BOTH sides of the implication are false. So the
+   restriction is exact, not a shortcut -- every triple it drops is one that
+   discharges vacuously anyway -- and it cuts the check 8x. The negative control
+   in specs/README.md (break Covers, watch LemmaCoverageIsSound fail) confirms
+   the restricted lemma still has teeth. *)
+CompleteFootprints == [reads : SUBSET Ids, updates : SUBSET Ids, under : {FALSE}]
+
 -------------------------------------------------------------------------------
 (* Algebraic properties of the relation as encoded *)
 -------------------------------------------------------------------------------
@@ -116,6 +130,53 @@ ASSUME LemmaValidatedPreservesUnderApproximation ==
 ASSUME LemmaMergePropagatesUnderApproximation ==
     \A f \in Footprints, g \in Footprints :
         MergeWith(f, g).under = (f.under \/ g.under)
+
+(*
+ * THE H6 FIX, and the reason it is safe to act on.
+ *
+ * If the DECLARED footprint covers the ACTUAL one, then every transaction the
+ * scheduler judged compatible with the declared footprint really is compatible
+ * with what the transaction actually touched. Contract C on `declared` therefore
+ * implies Contract C on `actual`, and the scheduling was sound after all.
+ *
+ * That is the entire justification for the commit-time coverage check: pass it
+ * and the run can publish; fail it and the transaction was scheduled on a
+ * footprint that did not describe it, so it must abort BEFORE publishing and
+ * re-run with the refined footprint. Checked here over every ordered TRIPLE of
+ * footprints in the universe, not argued.
+ *
+ * `actual` is required complete (~a.under) because it is: the log footprint is
+ * built by merging real log entries, and no entry can be under-approximated.
+ *)
+ASSUME LemmaCoverageIsSound ==
+    \A d \in CompleteFootprints, a \in CompleteFootprints, g \in CompleteFootprints :
+        (Covers(d, a) /\ IsCompatible(d, g)) => IsCompatible(a, g)
+
+(* Coverage is reflexive: an accurate footprint always covers itself, so a
+   transaction with a statically-known access set NEVER trips the check. This is
+   what bounds the fix's cost to the data-dependent path. *)
+ASSUME LemmaCoverageReflexive ==
+    \A f \in Footprints : Covers(f, f)
+
+(* A parent-structure READ covers a child-entry READ (the whole-map-read case:
+   the log expands it into a read-only entry per key, and every one of those is
+   covered) -- but a parent READ does NOT cover a child WRITE, because reading a
+   map does not announce that you will write a key in it. This asymmetry is why
+   the check cannot be a plain subset test. *)
+ASSUME DocumentsParentReadCoversChildRead ==
+    /\ Covers(FP({S}, {}), FP({E1}, {}))
+    /\ ~Covers(FP({S}, {}), FP({}, {E1}))
+
+(* A parent-structure WRITE covers child-entry writes AND reads -- the setVarMap
+   case, where the log expands a structure write into a per-key update entry. *)
+ASSUME DocumentsParentWriteCoversChildren ==
+    /\ Covers(FP({}, {S}), FP({}, {E1}))
+    /\ Covers(FP({}, {S}), FP({E1}, {}))
+
+(* And the H6 defect itself: declaring a write to one id does NOT cover writing a
+   DIFFERENT one. This is the case the check exists to catch. *)
+ASSUME DocumentsWrongIdIsNotCovered ==
+    ~Covers(FP({}, {PV1}), FP({}, {E1}))
 
 -------------------------------------------------------------------------------
 (* Positive controls: conflicts the relation DOES catch *)

--- a/src/main/scala/bengal/stm/model/runtime/IdFootprint.scala
+++ b/src/main/scala/bengal/stm/model/runtime/IdFootprint.scala
@@ -122,6 +122,34 @@ private[stm] case class IdFootprint(
   private[stm] def isCompatibleWith(input: IdFootprint): Boolean =
     !isUnderApproximated && !input.isUnderApproximated &&
       asymmetricCompatibleWith(input) && input.asymmetricCompatibleWith(this)
+
+  // SPEC: CommitSnapshotValid — the H6 fix. TRUE iff declaring THIS footprint
+  // excluded at least as much concurrency as declaring `actual` would have. If
+  // so, Contract C on this footprint implies Contract C on what the transaction
+  // really touched, and its scheduling was sound after all
+  // (LemmaCoverageIsSound in specs/common/FootprintLemmas.tla checks that
+  // exhaustively over every ordered triple of footprints — it is not argued).
+  //
+  // NOT a subset test on raw ids. That would be unusable as well as wrong: a
+  // whole-map READ legitimately expands, in the log, into a read-only entry for
+  // EVERY existing key (TxnLogValid.getVarMap), so the actual footprint properly
+  // contains ids the static walker never named. Those ids ARE covered — a
+  // parent-structure read conflicts with any child write via the relation's
+  // third conjunct — and a subset test would abort every whole-map read in the
+  // library.
+  //
+  // Hence the hierarchy, and note its asymmetry: an id is covered if this
+  // footprint names it OR names its PARENT, but a parent READ covers only a
+  // child READ, whereas a parent WRITE covers child reads and writes alike.
+  // Reading a map does not announce that you will write a key in it.
+  private[stm] def covers(actual: IdFootprint): Boolean =
+    actual.readIds.forall { id =>
+      combinedRawIds.contains(id.value) ||
+      id.parent.exists(p => combinedRawIds.contains(p.value))
+    } && actual.updatedIds.forall { id =>
+      updateRawIds.contains(id.value) ||
+      id.parent.exists(p => updateRawIds.contains(p.value))
+    }
 }
 
 private[stm] object IdFootprint {

--- a/src/main/scala/bengal/stm/runtime/TxnLogContext.scala
+++ b/src/main/scala/bengal/stm/runtime/TxnLogContext.scala
@@ -1089,12 +1089,18 @@ private[stm] trait TxnLogContext[F[_]] {
         .parTraverse(_.hasChangedSinceRead)
         .map(_.exists(identity))
 
+    // foldLeft from empty, NOT reduce: an EMPTY log is perfectly ordinary — a
+    // transaction of pure/delay steps touches nothing, and reading an absent map
+    // key records no entry at all — and `reduce` throws on an empty list. The
+    // bug was latent while this was only forced on the dirty path (where the log
+    // is non-empty by construction); the H6 coverage check forces it on every
+    // commit, which is what brought it out.
     override private[stm] lazy val idFootprint: F[IdFootprint] =
       log.values.toList
         .parTraverse { entry =>
           entry.idFootprint
         }
-        .map(_.reduce(_ mergeWith _))
+        .map(_.foldLeft(IdFootprint.empty)(_ mergeWith _))
 
     // SPEC: NoWaitsForCycle — the H2 fix. Acquire the write set's commitLocks
     // in ascending order of THE ID OF THE ENTITY THAT OWNS EACH LOCK. Because

--- a/src/main/scala/bengal/stm/runtime/TxnRuntimeContext.scala
+++ b/src/main/scala/bengal/stm/runtime/TxnRuntimeContext.scala
@@ -388,6 +388,34 @@ private[stm] trait TxnRuntimeContext[F[_]] {
             Async[F].delay((TxnLogError(ex), None))
         }
 
+    // SPEC: CommitSnapshotValid — the H6 fix. The scheduler placed this
+    // transaction using its DECLARED footprint, computed by the static-analysis
+    // walker BEFORE submitTxn — outside activeTransactions, outside any
+    // Contract-C window, and from LIVE reads. A transaction whose access set
+    // depends on a value it read can therefore be scheduled on a footprint that
+    // names the WRONG IDS: read a key from a var, have another transaction
+    // change that var in the gap before this one is scheduled, and the real run
+    // touches an entry nobody declared. Nothing throws, so the H3 flag never
+    // fires and the scheduler simply trusts a footprint that does not describe
+    // the transaction.
+    //
+    // So, under the locks and BEFORE publishing, ask whether the declared
+    // footprint COVERS what the run actually touched. If it does, Contract C on
+    // the declared footprint implies Contract C on the actual one and the
+    // scheduling was sound. If it does not, refine from the actual log and
+    // re-run — the same road the dirty path takes.
+    //
+    // Checking BEFORE the publish is what makes this work in both directions:
+    // our undeclared write never lands, so a peer's unvalidated read of it stays
+    // valid; and our own undeclared read never reaches a caller.
+    private def coversActualFootprint(actual: IdFootprint): Boolean =
+      // An under-approximated footprint is incompatible with everything (the H3
+      // fix), so this transaction ran ALONE. Nothing could change under it and
+      // its reads are valid whatever it touched, so coverage is meaningless
+      // here — and checking it would send every such transaction round again for
+      // no gain, since a partial footprint covers nothing by construction.
+      idFootprint.isUnderApproximated || idFootprint.covers(actual.getValidated)
+
     // SPEC: NoDoublePublish — log.commit below publishes the write set; a
     // second concurrent execute fiber for the same txn re-runs the whole
     // pipeline and publishes again (Scheduler.tla checks once-per-incarnation).
@@ -400,10 +428,18 @@ private[stm] trait TxnRuntimeContext[F[_]] {
                       Async[F]
                         .uncancelable { _ =>
                           log.withLock {
-                            Async[F].ifM[Option[V]](log.isDirty)(
-                              Async[F].delay(None),
-                              log.commit.as(logValue)
-                            )
+                            for {
+                              actual <- log.idFootprint
+                              sound  <- Async[F].delay(coversActualFootprint(actual))
+                              // An unsound placement is treated exactly like a
+                              // dirty log: release, refine, re-run. isDirty is
+                              // skipped when we already know we must refine.
+                              refine <- if (sound) log.isDirty else Async[F].pure(true)
+                              result <- Async[F].ifM[Option[V]](Async[F].pure(refine))(
+                                          Async[F].delay(None),
+                                          log.commit.as(logValue)
+                                        )
+                            } yield result
                           }
                         }
                         .flatMap { s =>
@@ -418,18 +454,29 @@ private[stm] trait TxnRuntimeContext[F[_]] {
                               )
                           )
                         }
+                    // The park path needs the same coverage check. A parked
+                    // transaction's DECLARED footprint is what the retry map
+                    // wakes it on (checkRetryQueue compares against it), so a
+                    // transaction that parks on a footprint not covering its
+                    // real reads can be left asleep by a conflictor the
+                    // scheduler never matched it against. Refine and re-run
+                    // instead, and it parks with a footprint that describes it.
                     case retry @ TxnLogRetry(_) =>
                       Async[F].uncancelable { _ =>
                         retry.validLog.withLock {
-                          Async[F].ifM[TxnResult](log.isDirty)(
-                            retry.validLog.idFootprint.map(footprint =>
-                              TxnResultLogDirty(footprint)
-                                .asInstanceOf[TxnResult]
-                            ),
-                            Async[F].delay(
-                              TxnResultRetry(retry.validLog).asInstanceOf[TxnResult]
-                            )
-                          )
+                          for {
+                            actual <- retry.validLog.idFootprint
+                            sound  <- Async[F].delay(coversActualFootprint(actual))
+                            refine <- if (sound) log.isDirty else Async[F].pure(true)
+                            result <- Async[F].ifM[TxnResult](Async[F].pure(refine))(
+                                        Async[F].delay(
+                                          TxnResultLogDirty(actual).asInstanceOf[TxnResult]
+                                        ),
+                                        Async[F].delay(
+                                          TxnResultRetry(retry.validLog).asInstanceOf[TxnResult]
+                                        )
+                                      )
+                          } yield result
                         }
                       }
                     case err @ TxnLogError(_) =>

--- a/src/test/scala/bengal/stm/model/runtime/IdFootprintSpec.scala
+++ b/src/test/scala/bengal/stm/model/runtime/IdFootprintSpec.scala
@@ -202,5 +202,99 @@ class IdFootprintSpec extends AnyFreeSpec with Matchers {
         a.isCompatibleWith(b) shouldBe false
       }
     }
+
+    // The H3 fix. An under-approximated footprint is not a small footprint, it
+    // is an unknown one, and there is no sound way to compare against a set you
+    // know to be incomplete.
+    "under-approximation" - {
+      "is incompatible with everything, including the empty footprint" in {
+        val unknown = IdFootprint(Set.empty, Set.empty, isUnderApproximated = true)
+        unknown.isCompatibleWith(IdFootprint.empty) shouldBe false
+        IdFootprint.empty.isCompatibleWith(unknown) shouldBe false
+        unknown.isCompatibleWith(unknown) shouldBe false
+        unknown.isCompatibleWith(IdFootprint(readIds = Set(id1), updatedIds = Set.empty)) shouldBe false
+      }
+
+      "does not serialize anything it shouldn't — complete disjoint footprints stay compatible" in {
+        val a = IdFootprint(readIds = Set(id1), updatedIds = Set.empty)
+        val b = IdFootprint(readIds = Set.empty, updatedIds = Set(id2))
+        a.isCompatibleWith(b) shouldBe true
+      }
+
+      "survives getValidated — a validated footprint must not regain the scheduler's trust" in {
+        // The runtime compares getValidated footprints EVERYWHERE, so if
+        // validation dropped the flag the whole fix would be a no-op.
+        IdFootprint(Set(id1), Set(id1), isUnderApproximated = true).getValidated.isUnderApproximated shouldBe true
+      }
+
+      "is contagious under merge" in {
+        val known   = IdFootprint(readIds = Set(id1), updatedIds = Set.empty)
+        val unknown = IdFootprint(Set.empty, Set.empty, isUnderApproximated = true)
+        known.mergeWith(unknown).isUnderApproximated shouldBe true
+        unknown.mergeWith(known).isUnderApproximated shouldBe true
+      }
+    }
+
+    // The H6 fix. `covers` asks whether declaring THIS footprint excluded at
+    // least as much concurrency as declaring the actual one would have. It is
+    // deliberately NOT a subset test, and the asymmetry below is why.
+    "covers" - {
+      "an accurate footprint covers itself, so a static access set never trips the check" in {
+        val f = IdFootprint(readIds = Set(id1, parentId), updatedIds = Set(id2))
+        f.covers(f) shouldBe true
+      }
+
+      "a parent-structure READ covers a child-entry READ" in {
+        // The whole-map-read case: the log expands `getVarMap` into a read-only
+        // entry for EVERY existing key, so the actual footprint properly
+        // contains ids the static walker never named. A subset test would abort
+        // every whole-map read in the library; these ids are genuinely covered,
+        // because a parent read conflicts with any child write (the H5 conjunct).
+        val declared = IdFootprint(readIds = Set(parentId), updatedIds = Set.empty)
+        val actual   = IdFootprint(readIds = Set(parentId, childId), updatedIds = Set.empty)
+        declared.covers(actual) shouldBe true
+      }
+
+      "a parent-structure READ does NOT cover a child-entry WRITE" in {
+        // Reading a map does not announce that you will write a key in it.
+        val declared = IdFootprint(readIds = Set(parentId), updatedIds = Set.empty)
+        val actual   = IdFootprint(readIds = Set.empty, updatedIds = Set(childId))
+        declared.covers(actual) shouldBe false
+      }
+
+      "a parent-structure WRITE covers child reads and writes alike" in {
+        // The setVarMap case: the log expands a structure write into a per-key
+        // update entry.
+        val declared = IdFootprint(readIds = Set.empty, updatedIds = Set(parentId))
+        declared.covers(IdFootprint(readIds = Set.empty, updatedIds = Set(childId))) shouldBe true
+        declared.covers(IdFootprint(readIds = Set(childId), updatedIds = Set.empty)) shouldBe true
+      }
+
+      "declaring a write to one id does NOT cover writing a different one — this is H6" in {
+        // A data-dependent key: the walker read the key source before the
+        // transaction was scheduled, that source changed, and the run touched an
+        // entry nobody declared.
+        val declared = IdFootprint(readIds = Set.empty, updatedIds = Set(id1))
+        val actual   = IdFootprint(readIds = Set.empty, updatedIds = Set(id2))
+        declared.covers(actual) shouldBe false
+      }
+
+      "nor does it cover a SIBLING entry of the same map — the map-key form of H6" in {
+        val sibling  = TxnVarRuntimeId(21, parent = Some(parentId))
+        val declared = IdFootprint(readIds = Set.empty, updatedIds = Set(childId))
+        declared.covers(IdFootprint(readIds = Set.empty, updatedIds = Set(sibling))) shouldBe false
+      }
+
+      "declaring a READ does not cover a WRITE of the same id" in {
+        val declared = IdFootprint(readIds = Set(id1), updatedIds = Set.empty)
+        val actual   = IdFootprint(readIds = Set.empty, updatedIds = Set(id1))
+        declared.covers(actual) shouldBe false
+      }
+
+      "an empty actual footprint is covered by anything" in {
+        IdFootprint.empty.covers(IdFootprint.empty) shouldBe true
+        IdFootprint(readIds = Set(id3), updatedIds = Set.empty).covers(IdFootprint.empty) shouldBe true
+      }
+    }
   }
 }


### PR DESCRIPTION
Confirms and fixes **H6** — the hole the H3 fix could not reach, and the last one standing. With this, **all six hypotheses H1–H6 are confirmed and fixed.**

## The defect

`staticAnalysisCompiler` runs in `TxnRuntime.commit` **before `submitTxn`** — outside `activeTransactions`, outside any Contract-C window — and it computes the access set by executing **live reads**. So a transaction whose keys or targets depend on a value it read can be scheduled on a footprint that names **the wrong ids**:

```scala
for { k <- keyVar.get        // analysis reads keyVar = "a"
      _ <- myMap.set(k, 1) } // so it DECLARES a write to entry (myMap, "a")
```

A peer commits `keyVar := "b"` in the gap before this transaction is scheduled. The real run — now inside the window — reads `"b"` and writes entry `(myMap, "b")`, an id the scheduler never knew about.

**Nothing throws.** The walker completed, so the H3 flag never fires, and the scheduler simply trusts a footprint that does not describe the transaction. Same mechanism as H3, same invariant: *an inaccurate declared footprint is an inaccurate declared footprint, whether it got that way by throwing or by racing.*

## The fix

Under the locks and **before publishing anything**, ask whether the declared footprint **covers** what the run actually touched. If it does, Contract C on the declared footprint implies Contract C on the actual one, and the scheduling was sound. If it does not, refine from the actual log and re-run — the road the dirty path already takes.

**Checking before the publish is what makes it work in both directions**: our undeclared write never lands, so a peer's unvalidated read of it stays valid; and our own undeclared read never reaches a caller.

## Coverage is *not* a subset test — this is the part that matters

The obvious implementation is wrong, and I nearly shipped it. A subset test on raw ids would be **unusable**: a whole-map read legitimately expands, in the log, into a read-only entry for **every existing key**, so the actual footprint properly *contains* ids the walker never named. Those ids **are** covered — a parent-structure read conflicts with any child write via the relation's third conjunct — and a subset test would abort **every whole-map read in the library**.

Hence the hierarchy, and note the asymmetry: an id is covered if the footprint names it **or names its parent** — but a parent **read** covers only a child **read**, whereas a parent **write** covers child reads and writes alike. *Reading a map does not announce that you will write a key in it.*

That is **proven, not argued**. `LemmaCoverageIsSound` checks `Covers(d,a) ∧ IsCompatible(d,g) ⇒ IsCompatible(a,g)` exhaustively over **every ordered triple** of footprints in the 4-id universe.

## A latent crash this exposed

`TxnLogValid.idFootprint` used `.reduce(_ mergeWith _)`, which **throws on an empty list** — and an empty log is perfectly ordinary (a transaction of `pure`/`delay` steps touches nothing; reading an absent map key records no entry at all). It was masked because `idFootprint` was only ever forced on the dirty path, where the log is non-empty by construction. Forcing it on every commit brought it straight out. Now `foldLeft` from empty.

## Verification

| | |
|---|---|
| `CommitH6.cfg` | **RED** pre-fix (15-state counterexample) → **CLEAN** post-fix |
| **NC-6** | Remove the check → red again, so the model still *detects* H6 |
| **NC-7** | Break `Covers` in H6's *exact* way (a declared write "covers" a **sibling** entry of the same map) → `LemmaCoverageIsSound` **fails**. The lemma specifically rejects H6 rather than being satisfiable by any plausible-looking definition |
| **166 tests** | All pass — including whole-map reads, `setVarMap` and absent-key reads, exactly the cases a naive subset test would have destroyed. **No spurious aborts on ordinary programs.** |
| `CommitDirty` | Still reaches `DirtyRestart` — the refinement path did not go vacuous under the new guard |
| Unit tests | Pin the coverage asymmetry directly |

## Cost

`log.idFootprint` is now computed on **every** commit rather than only on the dirty path — one extra fold over the log entries. Correctness first; if it shows up in a profile, the footprint can be accumulated during the log run instead.

## How H6 was found — worth recording

It wasn't found by staring at the code. It was **forced out by a fix**. Closing H3 made `CommitDirty.cfg` pass *vacuously*, and asking "so what **can** still go dirty?" had exactly one answer. That's the pattern the whole workstream ran on.

**Ten TLC expectations, all expected-clean. No pinned counterexamples remain anywhere in the repo.**