### PR TITLE
Add a serializability soak that scales, and instrument re-execution

### DIFF
--- a/src/test/scala/soak/History.scala
+++ b/src/test/scala/soak/History.scala
@@ -38,8 +38,8 @@ package soak
   *     ANTI-DEPENDENCY is the one that matters — it is the edge that unprotected reads create, and every anomaly this
   *     project has fixed (H3, H5, H6) is an rw cycle.
   *
-  * A cycle in that graph is, by Adya's theorem, precisely a violation of conflict-serializability. Detection is
-  * O(V + E), so it scales to millions of transactions where permutation checking dies at eight.
+  * A cycle in that graph is, by Adya's theorem, precisely a violation of conflict-serializability. Detection is O(V +
+  * E), so it scales to millions of transactions where permutation checking dies at eight.
   *
   * The cycle's shape also NAMES the anomaly, which is worth as much as detecting it: no rw edges is a write cycle;
   * exactly one is read skew; two or more is write skew / phantom.
@@ -66,7 +66,7 @@ object History {
 
   /** A transactional location: either a plain var or one entry of one map. */
   sealed trait Key
-  final case class VarKey(idx: Int)                extends Key
+  final case class VarKey(idx: Int) extends Key
   final case class EntryKey(map: Int, key: String) extends Key
 
   /** What one transaction observed and what it wrote.
@@ -94,7 +94,7 @@ object History {
   }
 
   private def keyName(k: Key): String = k match {
-    case VarKey(i)      => s"v$i"
+    case VarKey(i) => s"v$i"
     case EntryKey(m, s) => s"m$m[$s]"
   }
 
@@ -153,8 +153,8 @@ object History {
 
   private def lostAppends(finalState: Map[Key, Vector[Tag]], txns: List[TxnRecord]): List[Violation] =
     for {
-      t             <- txns
-      (key, tag)    <- t.appends.toList
+      t          <- txns
+      (key, tag) <- t.appends.toList
       if !finalState.getOrElse(key, Vector.empty).contains(tag)
     } yield LostAppend(t.id, key, tag)
 
@@ -170,9 +170,13 @@ object History {
   def buildGraph(finalState: Map[Key, Vector[Tag]], txns: List[TxnRecord]): List[Edge] = {
     val wwEdges: List[Edge] =
       finalState.toList.flatMap { case (key, order) =>
-        order.sliding(2).collect { case Vector(a, b) if writerOf(a) != writerOf(b) =>
-          Edge(writerOf(a), writerOf(b), WW, key)
-        }.toList
+        order
+          .sliding(2)
+          .collect {
+            case Vector(a, b) if writerOf(a) != writerOf(b) =>
+              Edge(writerOf(a), writerOf(b), WW, key)
+          }
+          .toList
       }
 
     val readEdges: List[Edge] =
@@ -225,7 +229,7 @@ object History {
             colour(e.to) match {
               case White =>
                 colour(e.to) = Grey
-                via(e.to) = e
+                via(e.to)    = e
                 stack.push((e.to, adj(e.to)))
               case Grey =>
                 // Back edge: e.to is on the current path, so walking `via`
@@ -235,7 +239,7 @@ object History {
                 while (cur != e.to) {
                   val in = via(cur)
                   path = in :: path
-                  cur = in.from
+                  cur  = in.from
                 }
                 return Some(Cycle(path))
               case _ => () // Black: already fully explored, cannot be on the current path

--- a/src/test/scala/soak/History.scala
+++ b/src/test/scala/soak/History.scala
@@ -1,0 +1,252 @@
+/*
+ * Copyright 2023 Greg von Nessi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.entrolution
+package soak
+
+/** Serializability checking by CYCLE DETECTION, after Adya's formalism and Jepsen's Elle.
+  *
+  * WHY NOT JUST TRY EVERY SERIAL ORDER. `SerializabilityOracleSpec` checks an observed outcome against every
+  * permutation of the transactions. That is exact, but it is O(n!) — it caps out around four transactions, which is why
+  * that suite generates two to four. Every defect this project has found (H1–H6) needed either deep interleaving or a
+  * specific operation mix, and none of them would have surfaced in a four-transaction window. To search where the bugs
+  * actually live, the checker has to scale.
+  *
+  * THE TRICK THAT MAKES IT CHEAP. Model every transactional value as an append-only LIST, and make the only mutation an
+  * append. Then the final list on a key IS the total order of writes to that key — recovered for free, with no
+  * bookkeeping, no timestamps and no reference model. From there, a read that observed some prefix tells you exactly
+  * where it sits relative to every writer of that key.
+  *
+  * THE GRAPH. Build the Direct Serialization Graph over transactions:
+  *
+  *   - ww(k): consecutive appends on k. The earlier writer precedes the later one.
+  *   - wr(k): a transaction read a prefix ending in someone's append, so that writer precedes it.
+  *   - rw(k): a transaction read a prefix and MISSED the next append, so it precedes that appender. This
+  *     ANTI-DEPENDENCY is the one that matters — it is the edge that unprotected reads create, and every anomaly this
+  *     project has fixed (H3, H5, H6) is an rw cycle.
+  *
+  * A cycle in that graph is, by Adya's theorem, precisely a violation of conflict-serializability. Detection is
+  * O(V + E), so it scales to millions of transactions where permutation checking dies at eight.
+  *
+  * The cycle's shape also NAMES the anomaly, which is worth as much as detecting it: no rw edges is a write cycle;
+  * exactly one is read skew; two or more is write skew / phantom.
+  *
+  * NOTE WHAT THE WORKLOAD MUST CONTAIN. Read-ONLY reads. A read-modify-write puts the read into the transaction's
+  * footprint, so the scheduler serializes it and no anomaly is possible. Every bug this project found was an
+  * UNPROTECTED READ — which is also precisely why the existing generator, whose every operation reads what it writes,
+  * could never have found one.
+  */
+object History {
+
+  type TxnId = Int
+  type Tag   = Long
+
+  /** A transaction appends `id * TagStride + seq`, so a tag names its writer. Transaction ids start at 1; id 0 is the
+    * virtual transaction that established the initial state.
+    */
+  val TagStride: Long = 1000000L
+
+  val InitTxn: TxnId = 0
+
+  def tagFor(txn: TxnId, seq: Int): Tag = txn.toLong * TagStride + seq.toLong
+  def writerOf(tag: Tag): TxnId         = (tag / TagStride).toInt
+
+  /** A transactional location: either a plain var or one entry of one map. */
+  sealed trait Key
+  final case class VarKey(idx: Int)                extends Key
+  final case class EntryKey(map: Int, key: String) extends Key
+
+  /** What one transaction observed and what it wrote.
+    *
+    * `reads` are READ-ONLY observations — a key the transaction read but did not append to. A key it appended to is
+    * ordered by the ww edges instead, and adding its implicit read would only duplicate them.
+    *
+    * A whole-map read records an observation for EVERY key in the pool, including an EMPTY vector for keys that were
+    * absent. That empty observation is what makes a PHANTOM visible: the reader saw no such key, someone inserted one,
+    * and the resulting rw edge says the reader must precede the inserter.
+    */
+  final case class TxnRecord(
+    id: TxnId,
+    reads: Map[Key, Vector[Tag]],
+    appends: Map[Key, Tag]
+  )
+
+  sealed trait EdgeKind
+  case object WW extends EdgeKind
+  case object WR extends EdgeKind
+  case object RW extends EdgeKind
+
+  final case class Edge(from: TxnId, to: TxnId, kind: EdgeKind, key: Key) {
+    override def toString: String = s"T$from -${kind.toString.toLowerCase}(${keyName(key)})-> T$to"
+  }
+
+  private def keyName(k: Key): String = k match {
+    case VarKey(i)      => s"v$i"
+    case EntryKey(m, s) => s"m$m[$s]"
+  }
+
+  /** Everything the checker can find wrong with a history. */
+  sealed trait Violation { def explain: String }
+
+  /** An append is not in the final state at all: someone's write was overwritten wholesale. A lost update. */
+  final case class LostAppend(txn: TxnId, key: Key, tag: Tag) extends Violation {
+    def explain: String =
+      s"LOST UPDATE: T$txn appended $tag to ${keyName(key)}, but it is absent from the final state — " +
+        "a concurrent writer overwrote it, so the two were never serialized against each other."
+  }
+
+  /** A read observed something that is not a prefix of the key's true write order. Appends only ever extend a list, so
+    * every legitimate observation is a prefix; anything else means the reader saw a state that never existed.
+    */
+  final case class ImpossibleRead(txn: TxnId, key: Key, observed: Vector[Tag], actual: Vector[Tag]) extends Violation {
+    def explain: String =
+      s"IMPOSSIBLE READ: T$txn read ${observed.mkString("[", ",", "]")} from ${keyName(key)}, which is not a prefix " +
+        s"of its true write order ${actual.mkString("[", ",", "]")} — that state never existed."
+  }
+
+  /** A cycle in the DSG: by Adya's theorem, exactly a violation of conflict-serializability. */
+  final case class Cycle(edges: List[Edge]) extends Violation {
+
+    /** The cycle's rw-edge count names the anomaly class. */
+    def anomaly: String = edges.count(_.kind == RW) match {
+      case 0 => "G0/G1c — write cycle or cyclic information flow"
+      case 1 => "G-single — read skew (a transaction saw one key before a writer and another after it)"
+      case _ => "G2 — write skew / phantom (an anti-dependency cycle: each read what the other then overwrote)"
+    }
+
+    def explain: String =
+      s"NOT SERIALIZABLE [${anomaly}]\n  cycle: ${edges.map(_.toString).mkString(" ")}"
+  }
+
+  /** Check a completed history.
+    *
+    * @param finalState
+    *   the true, total write order of every key, read after all transactions have committed
+    * @param txns
+    *   what each transaction observed and appended
+    * @return
+    *   every violation found (empty means the history is conflict-serializable)
+    */
+  def check(finalState: Map[Key, Vector[Tag]], txns: List[TxnRecord]): List[Violation] = {
+    val lost       = lostAppends(finalState, txns)
+    val impossible = impossibleReads(finalState, txns)
+
+    // A cycle search over a history that already contains lost updates or
+    // impossible reads would report noise derived from the corruption rather
+    // than from the interleaving, so report the primary faults alone.
+    if (lost.nonEmpty || impossible.nonEmpty) lost ++ impossible
+    else findCycle(buildGraph(finalState, txns)).toList
+  }
+
+  private def lostAppends(finalState: Map[Key, Vector[Tag]], txns: List[TxnRecord]): List[Violation] =
+    for {
+      t             <- txns
+      (key, tag)    <- t.appends.toList
+      if !finalState.getOrElse(key, Vector.empty).contains(tag)
+    } yield LostAppend(t.id, key, tag)
+
+  private def impossibleReads(finalState: Map[Key, Vector[Tag]], txns: List[TxnRecord]): List[Violation] =
+    for {
+      t               <- txns
+      (key, observed) <- t.reads.toList
+      actual = finalState.getOrElse(key, Vector.empty)
+      if !actual.startsWith(observed)
+    } yield ImpossibleRead(t.id, key, observed, actual)
+
+  /** ww, wr and rw edges, exactly as described in the class comment. */
+  def buildGraph(finalState: Map[Key, Vector[Tag]], txns: List[TxnRecord]): List[Edge] = {
+    val wwEdges: List[Edge] =
+      finalState.toList.flatMap { case (key, order) =>
+        order.sliding(2).collect { case Vector(a, b) if writerOf(a) != writerOf(b) =>
+          Edge(writerOf(a), writerOf(b), WW, key)
+        }.toList
+      }
+
+    val readEdges: List[Edge] =
+      for {
+        t               <- txns
+        (key, observed) <- t.reads.toList
+        order = finalState.getOrElse(key, Vector.empty)
+        if order.startsWith(observed) // impossible reads are reported separately
+        edge <- {
+          // wr: the last writer this transaction SAW must precede it.
+          val wr = observed.lastOption.map(writerOf).filter(_ != t.id).map(Edge(_, t.id, WR, key))
+          // rw: the next writer, which this transaction MISSED, must follow it.
+          // THIS is the anti-dependency, and it is the edge unprotected reads create.
+          val rw = order.lift(observed.length).map(writerOf).filter(_ != t.id).map(Edge(t.id, _, RW, key))
+          wr.toList ++ rw.toList
+        }
+      } yield edge
+
+    wwEdges ++ readEdges
+  }
+
+  /** Iterative DFS with an explicit stack — a soak history is far too deep for recursion. Returns the first cycle
+    * found, with its edges in order.
+    */
+  private def findCycle(edges: List[Edge]): Option[Cycle] = {
+    val adj: Map[TxnId, List[Edge]] = edges.groupBy(_.from).withDefaultValue(Nil)
+    val nodes: Set[TxnId]           = edges.flatMap(e => List(e.from, e.to)).toSet
+
+    val White = 0
+    val Grey  = 1
+    val Black = 2
+
+    val colour = scala.collection.mutable.Map.empty[TxnId, Int].withDefaultValue(White)
+    // The edge by which each node was entered, so a cycle can be reconstructed.
+    val via = scala.collection.mutable.Map.empty[TxnId, Edge]
+
+    def walk(root: TxnId): Option[Cycle] = {
+      // (node, remaining outgoing edges to explore)
+      val stack = scala.collection.mutable.Stack[(TxnId, List[Edge])]()
+      colour(root) = Grey
+      stack.push((root, adj(root)))
+
+      while (stack.nonEmpty) {
+        val (node, pending) = stack.pop()
+        pending match {
+          case Nil =>
+            colour(node) = Black
+          case e :: rest =>
+            stack.push((node, rest))
+            colour(e.to) match {
+              case White =>
+                colour(e.to) = Grey
+                via(e.to) = e
+                stack.push((e.to, adj(e.to)))
+              case Grey =>
+                // Back edge: e.to is on the current path, so walking `via`
+                // backwards from `node` to `e.to` reconstructs the cycle.
+                var path = List(e)
+                var cur  = node
+                while (cur != e.to) {
+                  val in = via(cur)
+                  path = in :: path
+                  cur = in.from
+                }
+                return Some(Cycle(path))
+              case _ => () // Black: already fully explored, cannot be on the current path
+            }
+        }
+      }
+      None
+    }
+
+    nodes.toList.sorted.collectFirst(Function.unlift { n =>
+      if (colour(n) == White) walk(n) else None
+    })
+  }
+}

--- a/src/test/scala/soak/HistorySpec.scala
+++ b/src/test/scala/soak/HistorySpec.scala
@@ -1,0 +1,177 @@
+/*
+ * Copyright 2023 Greg von Nessi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.entrolution
+package soak
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+import soak.History._
+
+/** The checker is the instrument, so the instrument gets calibrated first.
+  *
+  * A serializability checker that silently passes everything is worse than no checker at all: it manufactures
+  * confidence. So before pointing it at the STM, feed it histories whose verdicts are known by construction — the
+  * anomalies this project has actually fixed, hand-built — and confirm it names each one.
+  *
+  * This is the same discipline as the TLA+ negative controls: a clean run proves nothing until you have watched the
+  * thing go red for the right reason.
+  */
+class HistorySpec extends AnyFreeSpec with Matchers {
+
+  private val x: Key = VarKey(0)
+  private val y: Key = VarKey(1)
+
+  private def t(id: TxnId, reads: (Key, Vector[Tag])*)(appends: (Key, Tag)*): TxnRecord =
+    TxnRecord(id, reads.toMap, appends.toMap)
+
+  /** Map is invariant in its key type, so the final state has to be built at Key. */
+  private def state(pairs: (Key, Vector[Tag])*): Map[Key, Vector[Tag]] = pairs.toMap
+
+  "accepts a serializable history" - {
+
+    "a purely serial history" in {
+      // T1 appends to x, then T2 reads what T1 wrote and appends to y.
+      val t1x = tagFor(1, 0)
+      val t2y = tagFor(2, 0)
+      val finalState = state(x -> Vector(t1x), y -> Vector(t2y))
+      val txns = List(
+        t(1)(x -> t1x),
+        t(2, x -> Vector(t1x))(y -> t2y)
+      )
+      check(finalState, txns) shouldBe empty
+    }
+
+    "concurrent transactions touching disjoint keys" in {
+      val t1x = tagFor(1, 0)
+      val t2y = tagFor(2, 0)
+      val finalState = state(x -> Vector(t1x), y -> Vector(t2y))
+      check(finalState, List(t(1)(x -> t1x), t(2)(y -> t2y))) shouldBe empty
+    }
+
+    "a read that saw NOTHING is still serializable — it simply came first" in {
+      // T2 read x as empty and T1 later appended. That is a single rw edge and
+      // no cycle: T2 precedes T1. A checker that flagged this would be useless,
+      // because it would flag every legitimate concurrent read.
+      val t1x = tagFor(1, 0)
+      check(state(x -> Vector(t1x)), List(t(1)(x -> t1x), t(2, x -> Vector.empty)())) shouldBe empty
+    }
+  }
+
+  "catches the anomalies this project fixed" - {
+
+    "WRITE SKEW (G2) — each read what the other then wrote: H3, H6" in {
+      // T1: read y (empty), append x.   T2: read x (empty), append y.
+      // Neither saw the other's write, so each must precede the other. Cycle.
+      val t1x = tagFor(1, 0)
+      val t2y = tagFor(2, 0)
+      val finalState = state(x -> Vector(t1x), y -> Vector(t2y))
+      val txns = List(
+        t(1, y -> Vector.empty)(x -> t1x),
+        t(2, x -> Vector.empty)(y -> t2y)
+      )
+      val violations = check(finalState, txns)
+      violations should have size 1
+      val cycle = violations.head.asInstanceOf[Cycle]
+      cycle.edges.count(_.kind == RW) should be >= 2
+      cycle.anomaly should include("G2")
+    }
+
+    "PHANTOM (G2) — a whole-map read missed an insert: H5" in {
+      // Two transactions each read the whole map (observing NO entry for the
+      // key the other will insert) and then insert their own. The empty
+      // observation is what makes the phantom visible.
+      val ka = EntryKey(0, "a")
+      val kb = EntryKey(0, "b")
+      val t1a = tagFor(1, 0)
+      val t2b = tagFor(2, 0)
+      val finalState = state(ka -> Vector(t1a), kb -> Vector(t2b))
+      val txns = List(
+        t(1, ka -> Vector.empty, kb -> Vector.empty)(ka -> t1a),
+        t(2, ka -> Vector.empty, kb -> Vector.empty)(kb -> t2b)
+      )
+      val violations = check(finalState, txns)
+      violations should have size 1
+      violations.head.asInstanceOf[Cycle].anomaly should include("G2")
+    }
+
+    "READ SKEW (G-single) — a torn view across two keys: H6's probe" in {
+      // A transfer T1 appends to both x and y. Reader T2 saw x BEFORE the
+      // transfer and y AFTER it: exactly one rw edge, one wr edge, a cycle.
+      val t1x = tagFor(1, 0)
+      val t1y = tagFor(1, 1)
+      val finalState = state(x -> Vector(t1x), y -> Vector(t1y))
+      val txns = List(
+        t(1)(x -> t1x, y -> t1y),
+        t(2, x -> Vector.empty, y -> Vector(t1y))()
+      )
+      val violations = check(finalState, txns)
+      violations should have size 1
+      violations.head.asInstanceOf[Cycle].anomaly should include("G-single")
+    }
+
+    "LOST UPDATE — an append vanished from the final state" in {
+      // T1 and T2 both appended to x, but only T2's survived: T2 overwrote the
+      // list wholesale rather than extending it.
+      val t1x = tagFor(1, 0)
+      val t2x = tagFor(2, 0)
+      val violations = check(state(x -> Vector(t2x)), List(t(1)(x -> t1x), t(2)(x -> t2x)))
+      violations should have size 1
+      violations.head shouldBe a[LostAppend]
+    }
+
+    "IMPOSSIBLE READ — a state that never existed" in {
+      // T2 claims to have read [t2x] from x, but the true order is [t1x, t2x]:
+      // it saw a suffix, not a prefix, which no append-only history can produce.
+      val t1x = tagFor(1, 0)
+      val t2x = tagFor(2, 0)
+      val violations =
+        check(state(x -> Vector(t1x, t2x)), List(t(1)(x -> t1x), t(2, x -> Vector(t2x))(x -> t2x)))
+      violations should have size 1
+      violations.head shouldBe a[ImpossibleRead]
+    }
+  }
+
+  "scales past the permutation oracle" in {
+    // The permutation oracle is O(n!) and caps out around four transactions;
+    // this is the whole reason the checker exists. 5,000 transactions executed
+    // strictly in series: each reads the full prefix of x written before it,
+    // then appends. Serializable by construction, and the graph is a 5,000-node
+    // chain — so this measures the cost of cycle detection, not of the history.
+    val n = 5000
+    val order: Vector[Tag]                = (1 to n).map(i => tagFor(i, 0)).toVector
+    val finalState: Map[Key, Vector[Tag]] = state(x -> order, y -> Vector.empty[Tag])
+
+    val txns = (1 to n).map { i =>
+      TxnRecord(
+        id = i,
+        // Read y (never written by anyone: no edges) and, implicitly via its
+        // append, everything on x that preceded it.
+        reads   = Map(y -> Vector.empty[Tag]),
+        appends = Map(x -> tagFor(i, 0))
+      )
+    }.toList
+
+    val start = System.nanoTime()
+    check(finalState, txns) shouldBe empty
+    val millis = (System.nanoTime() - start) / 1000000
+
+    withClue(s"a 5,000-transaction history took ${millis}ms — detection should be near-linear in V+E: ") {
+      millis should be < 5000L
+    }
+  }
+}

--- a/src/test/scala/soak/HistorySpec.scala
+++ b/src/test/scala/soak/HistorySpec.scala
@@ -46,19 +46,19 @@ class HistorySpec extends AnyFreeSpec with Matchers {
 
     "a purely serial history" in {
       // T1 appends to x, then T2 reads what T1 wrote and appends to y.
-      val t1x = tagFor(1, 0)
-      val t2y = tagFor(2, 0)
+      val t1x        = tagFor(1, 0)
+      val t2y        = tagFor(2, 0)
       val finalState = state(x -> Vector(t1x), y -> Vector(t2y))
       val txns = List(
-        t(1)(x -> t1x),
+        t(1)(x                   -> t1x),
         t(2, x -> Vector(t1x))(y -> t2y)
       )
       check(finalState, txns) shouldBe empty
     }
 
     "concurrent transactions touching disjoint keys" in {
-      val t1x = tagFor(1, 0)
-      val t2y = tagFor(2, 0)
+      val t1x        = tagFor(1, 0)
+      val t2y        = tagFor(2, 0)
       val finalState = state(x -> Vector(t1x), y -> Vector(t2y))
       check(finalState, List(t(1)(x -> t1x), t(2)(y -> t2y))) shouldBe empty
     }
@@ -77,8 +77,8 @@ class HistorySpec extends AnyFreeSpec with Matchers {
     "WRITE SKEW (G2) — each read what the other then wrote: H3, H6" in {
       // T1: read y (empty), append x.   T2: read x (empty), append y.
       // Neither saw the other's write, so each must precede the other. Cycle.
-      val t1x = tagFor(1, 0)
-      val t2y = tagFor(2, 0)
+      val t1x        = tagFor(1, 0)
+      val t2y        = tagFor(2, 0)
       val finalState = state(x -> Vector(t1x), y -> Vector(t2y))
       val txns = List(
         t(1, y -> Vector.empty)(x -> t1x),
@@ -95,10 +95,10 @@ class HistorySpec extends AnyFreeSpec with Matchers {
       // Two transactions each read the whole map (observing NO entry for the
       // key the other will insert) and then insert their own. The empty
       // observation is what makes the phantom visible.
-      val ka = EntryKey(0, "a")
-      val kb = EntryKey(0, "b")
-      val t1a = tagFor(1, 0)
-      val t2b = tagFor(2, 0)
+      val ka         = EntryKey(0, "a")
+      val kb         = EntryKey(0, "b")
+      val t1a        = tagFor(1, 0)
+      val t2b        = tagFor(2, 0)
       val finalState = state(ka -> Vector(t1a), kb -> Vector(t2b))
       val txns = List(
         t(1, ka -> Vector.empty, kb -> Vector.empty)(ka -> t1a),
@@ -112,8 +112,8 @@ class HistorySpec extends AnyFreeSpec with Matchers {
     "READ SKEW (G-single) — a torn view across two keys: H6's probe" in {
       // A transfer T1 appends to both x and y. Reader T2 saw x BEFORE the
       // transfer and y AFTER it: exactly one rw edge, one wr edge, a cycle.
-      val t1x = tagFor(1, 0)
-      val t1y = tagFor(1, 1)
+      val t1x        = tagFor(1, 0)
+      val t1y        = tagFor(1, 1)
       val finalState = state(x -> Vector(t1x), y -> Vector(t1y))
       val txns = List(
         t(1)(x -> t1x, y -> t1y),
@@ -127,8 +127,8 @@ class HistorySpec extends AnyFreeSpec with Matchers {
     "LOST UPDATE — an append vanished from the final state" in {
       // T1 and T2 both appended to x, but only T2's survived: T2 overwrote the
       // list wholesale rather than extending it.
-      val t1x = tagFor(1, 0)
-      val t2x = tagFor(2, 0)
+      val t1x        = tagFor(1, 0)
+      val t2x        = tagFor(2, 0)
       val violations = check(state(x -> Vector(t2x)), List(t(1)(x -> t1x), t(2)(x -> t2x)))
       violations should have size 1
       violations.head shouldBe a[LostAppend]
@@ -152,7 +152,7 @@ class HistorySpec extends AnyFreeSpec with Matchers {
     // strictly in series: each reads the full prefix of x written before it,
     // then appends. Serializable by construction, and the graph is a 5,000-node
     // chain — so this measures the cost of cycle detection, not of the history.
-    val n = 5000
+    val n                                 = 5000
     val order: Vector[Tag]                = (1 to n).map(i => tagFor(i, 0)).toVector
     val finalState: Map[Key, Vector[Tag]] = state(x -> order, y -> Vector.empty[Tag])
 

--- a/src/test/scala/soak/SerializabilitySoakSpec.scala
+++ b/src/test/scala/soak/SerializabilitySoakSpec.scala
@@ -129,15 +129,15 @@ class SerializabilitySoakSpec extends AnyFreeSpec with Matchers {
   // ---------------------------------------------------------------------------
 
   sealed private trait Op
-  private case class ReadVar(i: Int)                extends Op
-  private case class AppendVar(i: Int)              extends Op
-  private case class ReadKey(m: Int, k: String)     extends Op
-  private case class AppendKey(m: Int, k: String)   extends Op
-  private case class ReadWholeMap(m: Int)           extends Op
+  private case class ReadVar(i: Int) extends Op
+  private case class AppendVar(i: Int) extends Op
+  private case class ReadKey(m: Int, k: String) extends Op
+  private case class AppendKey(m: Int, k: String) extends Op
+  private case class ReadWholeMap(m: Int) extends Op
   private case class DataDepAppend(src: Int, m: Int) extends Op
-  private case class DataDepRead(src: Int, m: Int)   extends Op
-  private case class Transfer(m: Int, i: Int)        extends Op
-  private case object UnderDeclare                  extends Op
+  private case class DataDepRead(src: Int, m: Int) extends Op
+  private case class Transfer(m: Int, i: Int) extends Op
+  private case object UnderDeclare extends Op
 
   private def genOps(rnd: Random): List[Op] =
     List.fill(opsPerTxn) {
@@ -154,7 +154,7 @@ class SerializabilitySoakSpec extends AnyFreeSpec with Matchers {
         case n if n < 80 => DataDepAppend(rnd.nextInt(NumVars), rnd.nextInt(NumMaps))
         case n if n < 88 => DataDepRead(rnd.nextInt(NumVars), rnd.nextInt(NumMaps))
         case n if n < 96 => Transfer(rnd.nextInt(NumMaps), rnd.nextInt(KeyPool.size))
-        case _           => UnderDeclare
+        case _ => UnderDeclare
       }
     }
 
@@ -262,7 +262,7 @@ class SerializabilitySoakSpec extends AnyFreeSpec with Matchers {
             for {
               v <- vars(src).get
               _ <- STM[IO].fromF(IO.sleep(2.millis))
-              i = v.length % KeyPool.size
+              i  = v.length % KeyPool.size
               k1 = KeyPool(i)
               k2 = KeyPool((i + 1) % KeyPool.size)
               c1 <- maps(m).get(k1)
@@ -270,7 +270,7 @@ class SerializabilitySoakSpec extends AnyFreeSpec with Matchers {
               c2 <- maps(m).get(k2)
             } yield rec.copy(
               reads = rec.reads
-                + ((VarKey(src): Key)    -> v)
+                + ((VarKey(src): Key)     -> v)
                 + ((EntryKey(m, k1): Key) -> c1.getOrElse(Vector.empty))
                 + ((EntryKey(m, k2): Key) -> c2.getOrElse(Vector.empty))
             )

--- a/src/test/scala/soak/SerializabilitySoakSpec.scala
+++ b/src/test/scala/soak/SerializabilitySoakSpec.scala
@@ -1,0 +1,416 @@
+/*
+ * Copyright 2023 Greg von Nessi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.entrolution
+package soak
+
+import java.util.concurrent.atomic.AtomicIntegerArray
+
+import scala.concurrent.duration._
+import scala.util.Random
+
+import cats.effect.IO
+import cats.effect.implicits._
+import cats.effect.unsafe.implicits.global
+import cats.syntax.all._
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+import bengal.stm.STM
+import bengal.stm.model._
+import bengal.stm.syntax.all._
+import soak.History._
+
+/** The serializability soak: many concurrent transactions, the FULL operation surface, checked by cycle detection.
+  *
+  * WHAT THIS EXISTS TO COVER. `SerializabilityOracleSpec` checks outcomes against every serial permutation, which is
+  * exact but O(n!) — it generates two to four transactions and only point operations. Every defect this project found
+  * (H1–H6) lived outside that window. This suite trades exactness for reach: cycle detection in the dependency graph
+  * (see `History`) is O(V+E), so the workload can be hundreds of transactions deep and carry the operations the
+  * generator omits.
+  *
+  * THE OPERATIONS, AND THE DEFECT EACH ONE REACHES:
+  *
+  *   - read-only reads — the anti-dependency edges that make anomalies visible at all. A read-modify-write puts its
+  *     read into the footprint, so the scheduler serializes it; EVERY bug found here was an UNPROTECTED read, which is
+  *     exactly why a generator whose every operation reads what it writes could never find one.
+  *   - whole-map reads (H5) — the phantom idiom, excluded from the generated oracle suite.
+  *   - new-key inserts (H5, H2) — every map key starts absent, so every first append takes the map-lock fallback.
+  *   - transactions spanning TWO maps (H2) — the lock-ordering path.
+  *   - data-dependent keys (H6) — a key computed from a value read before the transaction was scheduled.
+  *   - under-declared transactions (H3) — a read-your-own-write with a partial continuation, which throws in the
+  *     static-analysis pass and nowhere else.
+  *
+  * NOT COVERED, deliberately: deletes and whole-map WRITES. Both destroy a key's list, and the append-only history is
+  * what makes the write order recoverable for free. They need their own instrument.
+  *
+  * ===========================================================================
+  * WHAT THIS SUITE ACTUALLY DETECTS — measured, not assumed
+  * ===========================================================================
+  * A soak that has never been watched go red is a rubber stamp. Each fix was reverted in turn and the soak re-run:
+  *
+  *   H5 (phantom)           reverted -> CAUGHT, correctly classified G2
+  *   H3 (under-declaration) reverted -> CAUGHT, correctly classified G2
+  *   H6 (data-dependent)    reverted -> ***NOT CAUGHT***
+  *
+  * THE H6 GAP IS REAL, AND IS STATED HERE RATHER THAN ENGINEERED AWAY. Disabling the H6 coverage check leaves this
+  * suite GREEN. It does not cover H6, and nobody reading a green run should believe otherwise. `DataDependentFootprintSpec`
+  * covers H6 deterministically; this suite does not.
+  *
+  * Why it escapes is worth understanding. The DIVERGENCE is rampant — the meter below reports that around 80% of
+  * data-dependent operations name a different entry in the analysis pass than the run actually touches. But a
+  * divergence is not yet an ANOMALY. To become one it needs a four-way coincidence: the reader's run-time keys must
+  * land on exactly the entries some concurrent transaction is writing; the two must be compatible on everything ELSE
+  * they touch (with several operations each they usually are not, so the scheduler serializes them and the chance is
+  * gone); and the reader's two reads must straddle that transaction's publish, which is a `parTraverse` and so is
+  * tearable but brief. Random search does not assemble that. The H6 probe had to ENGINEER every one of those
+  * conditions — which, in hindsight, was the clue.
+  *
+  * Two things follow, and both are worth saying plainly. H6 is a real defect but a rare one to hit by chance, so its
+  * fix is insurance rather than a fire. And randomized testing would never have found it: only the model did.
+  *
+  * INSTRUMENTATION. Each transaction counts how many times its body actually EXECUTES — once in the static-analysis
+  * pass plus once per admitted run — so a clean, uncontended transaction is 2. Anything above that is re-execution:
+  * dirty retries, H6 coverage aborts, spurious wakeups. This matters because a transaction body re-runs in full, so any
+  * effect a user embeds in it re-runs too, and the H6 fix ADDED a reason to abort. The numbers are reported on every
+  * run and bounded, so a livelock shows up as a red test rather than as a slow one.
+  */
+private object DivergenceMeter {
+  private val seen = new java.util.concurrent.ConcurrentHashMap[(Int, Int), java.util.Set[String]]()
+
+  /** Called from inside the transaction body, so it fires once in the static-analysis pass and once per admitted run.
+    * If the two passes computed DIFFERENT keys from the same source value, the declared footprint named an entry the
+    * transaction did not touch — H6's divergence, measured rather than assumed.
+    */
+  def observe(txn: Int, op: Int, key: String): Unit = {
+    seen
+      .computeIfAbsent((txn, op), _ => java.util.concurrent.ConcurrentHashMap.newKeySet[String]())
+      .add(key)
+    ()
+  }
+
+  def diverged: Int = {
+    var n = 0
+    seen.forEach((_, ks) => if (ks.size() > 1) n += 1)
+    n
+  }
+
+  def observed: Int = seen.size()
+}
+
+class SerializabilitySoakSpec extends AnyFreeSpec with Matchers {
+
+  private val NumVars = 6
+  private val NumMaps = 2
+  private val KeyPool = Vector("k0", "k1", "k2", "k3", "k4", "k5")
+
+  /** Long mode: `-Dbengal.soak=long`. The default is sized to run in the normal test matrix. */
+  private val longMode = sys.props.get("bengal.soak").contains("long")
+
+  private val rounds     = if (longMode) 40 else 12
+  private val txnsPerRun = if (longMode) 400 else 80
+  private val opsPerTxn  = 6
+
+  // ---------------------------------------------------------------------------
+  // Workload
+  // ---------------------------------------------------------------------------
+
+  sealed private trait Op
+  private case class ReadVar(i: Int)                extends Op
+  private case class AppendVar(i: Int)              extends Op
+  private case class ReadKey(m: Int, k: String)     extends Op
+  private case class AppendKey(m: Int, k: String)   extends Op
+  private case class ReadWholeMap(m: Int)           extends Op
+  private case class DataDepAppend(src: Int, m: Int) extends Op
+  private case class DataDepRead(src: Int, m: Int)   extends Op
+  private case class Transfer(m: Int, i: Int)        extends Op
+  private case object UnderDeclare                  extends Op
+
+  private def genOps(rnd: Random): List[Op] =
+    List.fill(opsPerTxn) {
+      rnd.nextInt(100) match {
+        // The mix is load-bearing and was tuned against the negative controls,
+        // not by taste: DILUTING ReadWholeMap silently stopped the suite from
+        // catching a reverted H5, which is exactly the coverage loss the
+        // controls exist to catch. Change these weights and re-run the controls.
+        case n if n < 16 => ReadVar(rnd.nextInt(NumVars))
+        case n if n < 30 => AppendVar(rnd.nextInt(NumVars))
+        case n if n < 40 => ReadKey(rnd.nextInt(NumMaps), KeyPool(rnd.nextInt(KeyPool.size)))
+        case n if n < 58 => AppendKey(rnd.nextInt(NumMaps), KeyPool(rnd.nextInt(KeyPool.size)))
+        case n if n < 74 => ReadWholeMap(rnd.nextInt(NumMaps)) // the H5 detector
+        case n if n < 80 => DataDepAppend(rnd.nextInt(NumVars), rnd.nextInt(NumMaps))
+        case n if n < 88 => DataDepRead(rnd.nextInt(NumVars), rnd.nextInt(NumMaps))
+        case n if n < 96 => Transfer(rnd.nextInt(NumMaps), rnd.nextInt(KeyPool.size))
+        case _           => UnderDeclare
+      }
+    }
+
+  // ---------------------------------------------------------------------------
+  // Building the transaction, and recording what it observed
+  // ---------------------------------------------------------------------------
+
+  private def toTxn(
+    txnId: TxnId,
+    ops: List[Op],
+    vars: List[TxnVar[IO, Vector[Tag]]],
+    maps: List[TxnVarMap[IO, String, Vector[Tag]]],
+    execs: AtomicIntegerArray
+  )(implicit stm: STM[IO]): Txn[TxnRecord] = {
+
+    // Runs in the static-analysis pass AND in every admitted log run, which is
+    // precisely the count we want: how many times does this body really execute?
+    val countExecution: Txn[Unit] =
+      STM[IO].delay(execs.incrementAndGet(txnId))
+
+    val empty = TxnRecord(txnId, Map.empty, Map.empty)
+
+    val body = ops.zipWithIndex.foldLeft(STM[IO].pure(empty)) { case (acc, (op, opIdx)) =>
+      acc.flatMap { rec =>
+        val tag = tagFor(txnId, opIdx)
+        op match {
+
+          case ReadVar(i) =>
+            vars(i).get.map(v => rec.copy(reads = rec.reads + ((VarKey(i): Key) -> v)))
+
+          case AppendVar(i) =>
+            for {
+              cur <- vars(i).get
+              _   <- vars(i).set(cur :+ tag)
+            } yield rec.copy(appends = rec.appends + ((VarKey(i): Key) -> tag))
+
+          case ReadKey(m, k) =>
+            maps(m).get(k).map { ov =>
+              rec.copy(reads = rec.reads + ((EntryKey(m, k): Key) -> ov.getOrElse(Vector.empty)))
+            }
+
+          case AppendKey(m, k) =>
+            // Every key starts ABSENT, so the first append to it is a new-key
+            // insert — the map-lock fallback, and H2's path.
+            for {
+              cur <- maps(m).get(k)
+              _   <- maps(m).set(k, cur.getOrElse(Vector.empty) :+ tag)
+            } yield rec.copy(appends = rec.appends + ((EntryKey(m, k): Key) -> tag))
+
+          case ReadWholeMap(m) =>
+            // H5's idiom. Record an observation for EVERY key in the pool,
+            // including an EMPTY one for keys that are absent — that empty
+            // observation is what makes a phantom visible to the checker.
+            maps(m).get.map { mm =>
+              val observed: Map[Key, Vector[Tag]] =
+                KeyPool.map(k => (EntryKey(m, k): Key) -> mm.getOrElse(k, Vector.empty)).toMap
+              rec.copy(reads = rec.reads ++ observed)
+            }
+
+          case DataDepAppend(src, m) =>
+            // H6's path: the key is computed from a value READ, so the static
+            // analysis names whatever key the source held when IT ran — which
+            // need not be the key the real run touches.
+            //
+            // THE PAUSE IS LOAD-BEARING, and it is not cheating. The window
+            // H6 lives in is [analysis reads the source, log run reads it
+            // again]. TxnRuntime.commit runs the walker BEFORE submitTxn, so
+            // that window is real; its WIDTH in production is whatever the
+            // scheduler, a dependency wait, a GC pause or thread contention
+            // makes it, which is routinely milliseconds. A test that only ever
+            // samples the microsecond case under-explores a window the system
+            // genuinely has, and it shows: without this pause the soak PASSES
+            // with the H6 fix disabled (negative control NC-B), which would
+            // have been false confidence. The pause widens an existing window;
+            // it does not manufacture one.
+            for {
+              v <- vars(src).get
+              _ <- STM[IO].fromF(IO.sleep(2.millis))
+              k = KeyPool(v.length % KeyPool.size)
+              _   <- STM[IO].delay(DivergenceMeter.observe(txnId, opIdx, k))
+              cur <- maps(m).get(k)
+              _   <- maps(m).set(k, cur.getOrElse(Vector.empty) :+ tag)
+            } yield rec.copy(
+              reads   = rec.reads + ((VarKey(src): Key) -> v),
+              appends = rec.appends + ((EntryKey(m, k): Key) -> tag)
+            )
+
+          case DataDepRead(src, m) =>
+            // H6 from the READER's side, and this is the half that actually
+            // exposes it. A data-dependent WRITE is still protected against
+            // whole-map readers, because the wrong key it declares has the SAME
+            // PARENT as the right one and the relation's parent rule catches it
+            // anyway. What is NOT protected is a data-dependent READ: its
+            // declared footprint names the wrong entry, so a writer of the entry
+            // it REALLY reads is judged compatible with it and runs concurrently.
+            // Two of these in one transaction can then straddle another
+            // transaction's publish — which is not atomic, being a parTraverse
+            // over the log entries — and observe a TORN write set. That is a
+            // G-single cycle, and it is exactly the shape of the H6 probe.
+            // Reads an ADJACENT PAIR of entries, both data-dependent and both
+            // therefore undeclared. One unprotected read is only an rw edge; a
+            // cycle needs TWO, straddling another transaction's publish -- and
+            // that publish is not atomic (log.commit is a parTraverse over the
+            // entries). The pause between the reads is the straddle window.
+            for {
+              v <- vars(src).get
+              _ <- STM[IO].fromF(IO.sleep(2.millis))
+              i = v.length % KeyPool.size
+              k1 = KeyPool(i)
+              k2 = KeyPool((i + 1) % KeyPool.size)
+              c1 <- maps(m).get(k1)
+              _  <- STM[IO].fromF(IO.sleep(2.millis))
+              c2 <- maps(m).get(k2)
+            } yield rec.copy(
+              reads = rec.reads
+                + ((VarKey(src): Key)    -> v)
+                + ((EntryKey(m, k1): Key) -> c1.getOrElse(Vector.empty))
+                + ((EntryKey(m, k2): Key) -> c2.getOrElse(Vector.empty))
+            )
+
+          case Transfer(m, i) =>
+            // Appends to an ADJACENT PAIR of entries in one transaction -- an
+            // ordinary "move something from here to there". Accurately declared,
+            // so it is correct in itself; it is the counterpart a data-dependent
+            // reader can tear.
+            val k1 = KeyPool(i)
+            val k2 = KeyPool((i + 1) % KeyPool.size)
+            for {
+              c1 <- maps(m).get(k1)
+              _  <- maps(m).set(k1, c1.getOrElse(Vector.empty) :+ tag)
+              c2 <- maps(m).get(k2)
+              _  <- maps(m).set(k2, c2.getOrElse(Vector.empty) :+ (tag + 500000L))
+            } yield rec.copy(
+              appends = rec.appends
+                + ((EntryKey(m, k1): Key) -> tag)
+                + ((EntryKey(m, k2): Key) -> (tag + 500000L))
+            )
+
+          case UnderDeclare =>
+            // H3's path. Write a scratch key, read it back, and apply a PARTIAL
+            // continuation to the result. The analysis pass never applied the
+            // write, so it reads None and `.get` throws — there, and nowhere
+            // else. Everything after this point goes undeclared, which the fix
+            // must flag and serialize.
+            val scratch = s"scratch-$txnId"
+            for {
+              _  <- maps(0).set(scratch, Vector(tag))
+              ov <- maps(0).get(scratch)
+              _  <- STM[IO].delay(ov.get)
+            } yield rec.copy(appends = rec.appends + ((EntryKey(0, scratch): Key) -> tag))
+        }
+      }
+    }
+
+    // A key this transaction APPENDED to is ordered by the write chain, and its
+    // implicit read would only duplicate those edges. `reads` means read-ONLY.
+    countExecution.flatMap(_ => body).map(r => r.copy(reads = r.reads -- r.appends.keySet))
+  }
+
+  // ---------------------------------------------------------------------------
+  // Running one round
+  // ---------------------------------------------------------------------------
+
+  private case class RoundResult(
+    finalState: Map[Key, Vector[Tag]],
+    records: List[TxnRecord],
+    executions: Vector[Int]
+  )
+
+  private def runRound(seed: Long): RoundResult = {
+    val rnd      = new Random(seed)
+    val workload = List.fill(txnsPerRun)(genOps(rnd))
+    val execs    = new AtomicIntegerArray(txnsPerRun + 1)
+
+    STM
+      .runtime[IO]
+      .flatMap { implicit stm =>
+        for {
+          vars <- (0 until NumVars).toList.traverse(_ => TxnVar.of[IO, Vector[Tag]](Vector.empty))
+          maps <- (0 until NumMaps).toList.traverse(_ => TxnVarMap.of[IO, String, Vector[Tag]](Map.empty))
+
+          records <- workload.zipWithIndex.parTraverse { case (ops, i) =>
+                       toTxn(i + 1, ops, vars, maps, execs).commit
+                     }
+
+          finalVars <- vars.zipWithIndex.traverse { case (v, i) =>
+                         v.get.commit.map(l => (VarKey(i): Key) -> l)
+                       }
+          finalMaps <- maps.zipWithIndex.traverse { case (m, i) =>
+                         m.get.commit.map { mm =>
+                           mm.toList.map { case (k, l) => (EntryKey(i, k): Key) -> l }
+                         }
+                       }
+        } yield RoundResult(
+          finalState = (finalVars ++ finalMaps.flatten).toMap,
+          records    = records,
+          executions = (1 to txnsPerRun).map(execs.get).toVector
+        )
+      }
+      // A lost wakeup or a lock cycle would hang rather than fail; the timeout
+      // turns either into a red test with the round's seed in the message.
+      .timeout(if (longMode) 5.minutes else 90.seconds)
+      .unsafeRunSync()
+  }
+
+  // ---------------------------------------------------------------------------
+  // The soak
+  // ---------------------------------------------------------------------------
+
+  "concurrent workloads over the full operation surface are serializable" in {
+    val allExecs = Vector.newBuilder[Int]
+
+    (1 to rounds).foreach { round =>
+      val seed   = 0xbe9a1L * round
+      val result = runRound(seed)
+      allExecs ++= result.executions
+
+      val violations = History.check(result.finalState, result.records)
+
+      withClue(
+        s"round $round (seed $seed, $txnsPerRun txns x $opsPerTxn ops) produced a history that no serial order " +
+          s"explains:\n${violations.map("  " + _.explain).mkString("\n")}\n"
+      ) {
+        violations shouldBe empty
+      }
+    }
+
+    // ---- instrumentation ----
+    //
+    // A body executes ONCE in the static-analysis pass plus once per admitted
+    // run, so 2 is the floor and anything above it is re-execution: a dirty
+    // retry, an H6 coverage abort, or a spurious wakeup. This is user-visible —
+    // effects embedded in a transaction re-run with it — and the H6 fix added a
+    // reason to abort, so it is worth watching rather than assuming.
+    val execs = allExecs.result()
+    val mean  = execs.sum.toDouble / execs.size
+    val max   = execs.max
+    val reRun = execs.count(_ > 2)
+
+    info(
+      s"data-dependent footprint DIVERGENCE: ${DivergenceMeter.diverged} of ${DivergenceMeter.observed} " +
+        "data-dependent operations named a different entry in the static-analysis pass than the run actually " +
+        "touched. Every one of those is scheduled on a footprint that does not describe it, and is caught only by " +
+        "the H6 commit-time coverage check."
+    )
+    info(
+      f"body executions: mean $mean%.2f (floor is 2: one analysis + one run), max $max, " +
+        f"${100.0 * reRun / execs.size}%.1f%% of transactions re-executed at least once " +
+        s"[${execs.size} transactions over $rounds rounds]"
+    )
+
+    withClue(
+      s"a transaction body executed $max times. The floor is 2, so this is a retry storm — most likely a livelock " +
+        "on the H6 coverage-abort path (refine, re-run, diverge again) or a spurious-wakeup spin: "
+    ) {
+      max should be <= 25
+    }
+  }
+}

--- a/src/test/scala/soak/SerializabilitySoakSpec.scala
+++ b/src/test/scala/soak/SerializabilitySoakSpec.scala
@@ -173,7 +173,10 @@ class SerializabilitySoakSpec extends AnyFreeSpec with Matchers {
     // Runs in the static-analysis pass AND in every admitted log run, which is
     // precisely the count we want: how many times does this body really execute?
     val countExecution: Txn[Unit] =
-      STM[IO].delay(execs.incrementAndGet(txnId))
+      STM[IO].delay {
+        execs.incrementAndGet(txnId)
+        () // incrementAndGet returns the new count; -Werror rejects discarding it
+      }
 
     val empty = TxnRecord(txnId, Map.empty, Map.empty)
 


### PR DESCRIPTION
Items **1 and 3** of the workload plan: a serializability checker that scales, driving the full operation surface, with re-execution instrumentation.

## Why the existing oracle can't do this

`SerializabilityOracleSpec` checks outcomes against **every serial permutation**. Exact, but O(n!) — it caps out around four transactions, which is why it generates 2–4, point-ops only. **Every defect this project found lived outside that window.**

## The checker (`soak/History.scala`)

Model every value as an **append-only list** and make the only mutation an append. The final list on a key is then the **total write order** for that key — recovered for free, with no timestamps and no reference model.

From there, build the Direct Serialization Graph (`ww`, `wr`, and the `rw` **anti-dependency** that unprotected reads create) and look for a **cycle**. By Adya's theorem a cycle is precisely a violation of conflict-serializability, and detection is **O(V+E)** — hundreds of transactions deep, where permutation checking dies at eight. The cycle's shape also **names** the anomaly (G0 / G-single / G2), which is worth as much as detecting it.

## The checker is calibrated before it's trusted

A serializability checker that silently passes everything is **worse than none** — it manufactures confidence. So it's fed hand-built histories whose verdicts are known by construction (write skew, phantom, read skew, lost update, impossible read) and confirmed to name each one — and to **accept** the legitimate ones, including the case that matters most: *a read that saw nothing is serializable*. A checker that flagged that would be useless.

## What it actually detects — measured by reverting each fix, not assumed

| Fix reverted | Result |
|---|---|
| **H5** (phantom) | **CAUGHT** — correctly classified G2 |
| **H3** (under-declaration) | **CAUGHT** — correctly classified G2 |
| **H6** (data-dependent) | ⚠️ **NOT CAUGHT** |

**The H6 gap is stated in the suite rather than engineered away.** Disabling the H6 check leaves this soak **green**, so it does not cover H6, and nobody reading a green run should believe otherwise. (`DataDependentFootprintSpec` covers H6 deterministically.)

**Why it escapes is the interesting part.** The *divergence* is rampant — the new meter reports **~80% of data-dependent operations name a different entry in the analysis pass than the run actually touches**. But a divergence is not yet an anomaly. Becoming one needs a four-way coincidence random search doesn't assemble, and the H6 probe had to **engineer** every one of those conditions — which, in hindsight, was the clue.

Two things follow, and both are worth saying plainly:
- **H6 is real but rare to hit by chance**, so its fix is insurance rather than a fire.
- **Randomized testing would never have found it.** Only the model did.

Also worth flagging: the op-mix weights are **load-bearing**. Diluting `ReadWholeMap` while adding new ops silently stopped the suite catching a reverted H5 — exactly the coverage loss the controls exist to catch. That's now a comment in the code.

## Instrumentation (item 3)

Every transaction counts how many times its body **really executes** — once in the static-analysis pass plus once per admitted run, so a clean uncontended transaction is **2**. Anything above is re-execution: a dirty retry, an H6 coverage abort, a spurious wakeup. This is **user-visible** (a body re-runs in full, so embedded effects re-run with it) and **the H6 fix added a reason to abort**, so it is measured rather than assumed.

```
body executions: mean 2.39 (floor 2), max 5, ~38% of transactions re-executed at least once
```

**No retry storm.** The max is bounded, so a livelock is a red test rather than a slow one.

## Scale

Default sizing runs in the normal matrix (12 rounds × 80 txns). `-Dbengal.soak=long` gives 40 × 400.

**177 tests** green on 2.13 and 3.3.7 under the full CI gate.

## Still open

**Item 4** (JMH throughput baseline) and **item 2** (retry/park/wake workloads).