### PR TITLE
Make the specs' expectations single-source, and their state counts generated

### DIFF
--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -61,106 +61,50 @@ jobs:
           echo "TLC version:"
           java -cp specs/tla2tools.jar tlc2.TLC -h 2>&1 | head -3
 
-      - name: Check Footprint lemmas (expected clean)
-        run: |
-          ./specs/check_expected.sh \
-            specs/common/FootprintLemmas.cfg \
-            specs/common/FootprintLemmas.tla \
-            NONE
-
-      - name: Check Scheduler (expected clean since the H4 fix)
-        run: |
-          ./specs/check_expected.sh \
-            specs/scheduler/Scheduler.cfg \
-            specs/scheduler/Scheduler.tla \
-            NONE
-
-      - name: Check Scheduler retry/park/wake (expected clean since the H1 fix)
-        run: |
-          ./specs/check_expected.sh \
-            specs/scheduler/SchedulerRetry.cfg \
-            specs/scheduler/Scheduler.tla \
-            NONE
-
-      # PINNED RED, and it must stay red. tm is SchedulerRetry's tr with one
-      # difference: its read records no log entry, which is what a waitFor on an
-      # ABSENT MAP KEY does. That makes anyReadChangedSinceRead — the SECOND of
-      # H1's two park guards — structurally blind, and the parker sleeps forever.
+      # ONE STEP, and that is the point. There used to be thirteen hand-written
+      # invocations here, each restating a config's expected verdict -- while the
+      # config's own header ALSO stated it, in prose. Nothing tied the two
+      # together, so they drifted: four headers read "EXPECTED RED" for months
+      # while these steps asserted NONE, and check_expected.sh could not see it
+      # because it only ever compares TLC's output to the argument it was handed.
+      # A config could equally ship with no stated verdict (CommitH6 did), or
+      # exist and be run by nothing at all.
       #
-      # This is the negative control for the guard: if it ever stops deadlocking,
-      # either the model stopped modelling the unlogged read or the park protocol
-      # changed shape. Both need a human. The FIX (logging the absent-key read,
-      # TxnLogContext.getVarMapValue) is what makes the real system the tr case,
-      # and SchedulerRetry.cfg — clean — is that pin.
-      - name: Check park guard against an unlogged read (pinned RED — negative control)
-        run: |
-          ./specs/check_expected.sh \
-            specs/scheduler/SchedulerAbsentKey.cfg \
-            specs/scheduler/Scheduler.tla \
-            DEADLOCK
+      # The config now declares its own expectation (\* @expect) and this globs
+      # the directory. There is no list here to forget to update, and no second
+      # declaration to disagree with. specs/expectations.sh --list also fails if a
+      # config states a verdict in PROSE, because a restatement is a thing that
+      # can rot.
+      - name: Validate the expectation registry
+        run: ./specs/expectations.sh --list
 
-      - name: Check Scheduler robustness (pinned, dispatch only)
+      - name: Model-check every expectation
+        run: ./specs/expectations.sh
+
+      # STATE COUNTS ROT SILENTLY, and prose discipline does not catch it: the
+      # Scheduler cfg advertised "~24k distinct states" against a real 846,000,
+      # and the lemma check was documented at "~1s" against a real 39s. Both sat
+      # there for months. specs/measured.tsv is generated from an actual run and
+      # committed; if a spec change moves the state space, this step rewrites the
+      # file and the diff fails the build, so the number cannot quietly diverge
+      # from the model.
+      - name: Re-measure state spaces and fail on drift
+        run: |
+          ./specs/expectations.sh --measure
+          git diff --exit-code specs/measured.tsv || {
+            echo "::error::The measured state spaces changed. If that is intended, commit the regenerated specs/measured.tsv and update the table in specs/README.md."
+            exit 1
+          }
+
+      # ...and the table in specs/README.md is checked against that measurement,
+      # because a guard that only watched the generated file would let the
+      # published table rot beside it. That is precisely how the 24k figure
+      # survived: it was chased out of one file and left in another.
+      - name: Check the published state-space table
+        run: ./specs/expectations.sh --check-readme
+
+      # SchedulerAborts is @run dispatch: nondeterministic failure injection, and
+      # a pinned counterexample rather than a clean verdict.
+      - name: Model-check dispatch-gated expectations
         if: github.event_name == 'workflow_dispatch'
-        run: |
-          ./specs/check_expected.sh \
-            specs/scheduler/SchedulerAborts.cfg \
-            specs/scheduler/Scheduler.tla \
-            CompletionAtMostOnce \
-            ALLOW_DEADLOCK
-
-      # --- Commit protocol (Spec A) ---
-      # H2, H3 and H6 are all FIXED; every config below is expected clean. What
-      # keeps a green run here from being worthless is the negative-control table
-      # in specs/README.md: reverting each fix must reproduce its counterexample.
-      # Those are run by hand, and NC-8 is worth knowing about before you trust
-      # this job — deleting the commit-time dirty check outright changes no
-      # verdict in any of the seven.
-
-      - name: Check commit protocol — H2 lock ordering (expected clean since the H2 fix)
-        run: |
-          ./specs/check_expected.sh \
-            specs/commit/CommitH2.cfg \
-            specs/commit/CommitProtocol.tla \
-            NONE
-
-      - name: Check commit protocol — H3 under-declared read skew (expected clean since the H3 fix)
-        run: |
-          ./specs/check_expected.sh \
-            specs/commit/CommitH3.cfg \
-            specs/commit/CommitProtocol.tla \
-            NONE
-
-      - name: Check commit protocol — H3 on the PARTIAL footprint ordinary code produces (expected clean since the H3 fix)
-        run: |
-          ./specs/check_expected.sh \
-            specs/commit/CommitH3Partial.cfg \
-            specs/commit/CommitProtocol.tla \
-            NONE
-
-      - name: Check commit protocol — H3 under-declared writer (expected clean since the H3 fix)
-        run: |
-          ./specs/check_expected.sh \
-            specs/commit/CommitH3Writer.cfg \
-            specs/commit/CommitProtocol.tla \
-            NONE
-
-      - name: Check commit protocol — H6 data-dependent footprint (expected clean since the H6 fix)
-        run: |
-          ./specs/check_expected.sh \
-            specs/commit/CommitH6.cfg \
-            specs/commit/CommitProtocol.tla \
-            NONE
-
-      - name: Check commit protocol — dirty refinement (expected clean)
-        run: |
-          ./specs/check_expected.sh \
-            specs/commit/CommitDirty.cfg \
-            specs/commit/CommitProtocol.tla \
-            NONE
-
-      - name: Check commit protocol — accurate footprints (expected clean since the H5 fix)
-        run: |
-          ./specs/check_expected.sh \
-            specs/commit/CommitAccurate.cfg \
-            specs/commit/CommitProtocol.tla \
-            NONE
+        run: ./specs/expectations.sh --all

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,15 +132,32 @@ The scheduler and commit protocols carry TLA+ specifications under `specs/`
 (see `specs/README.md`). PRs touching `TxnRuntimeContext.scala`,
 `TxnLogContext.scala`, `IdFootprint.scala`, or `TxnVarRuntimeId.scala` must
 update the specs to match — or state in the PR description why no protocol
-behaviour changed. CI enforces two things on these paths: `// SPEC:` anchors
-listed in `specs/README.md` must exist, and pinned model-checking
-expectations must reproduce (a pinned counterexample that stops reproducing
-means the protocol changed — update the spec and `specs/README.md`'s verdict
-table together).
+behaviour changed.
 
-`specs/README.md` is the **single source of truth for verdicts**. Do not record a
-verdict anywhere else; two copies of a verdict is how the last set of them drifted
-apart.
+```bash
+./specs/expectations.sh --list          # validate the registry (no TLC; instant)
+./specs/expectations.sh                 # model-check everything CI checks
+./specs/verify_anchors.sh               # every // SPEC: anchor maps to a row
+```
+
+**Every config declares its own expected verdict**, in a `\* @expect` directive at
+the top of the `.cfg`. That is the only place a verdict is stated — CI derives its
+steps from the directory rather than from a hand-maintained list, so a config with
+no verdict, or a config nothing runs, both fail the build.
+
+Do **not** restate the verdict in the config's prose. `--list` rejects it. Explain
+*why* a config verifies as it does at any length; just do not say *what* it
+verifies as in a second place. Two copies of a verdict is exactly how the last set
+drifted: four headers read "EXPECTED RED" for months while CI asserted clean, and
+nothing could see the contradiction because one was a sentence and the other was a
+command-line argument.
+
+State counts are **generated, not remembered** (`specs/measured.tsv`). If a spec
+change moves the state space, CI regenerates the file, the diff fails the build,
+and you update `specs/README.md`'s table to match. Do not hand-edit either.
+
+If a pinned counterexample stops reproducing, the protocol changed. Update the
+spec, the config's `@expect`, and the verdict table in `specs/README.md`.
 
 ## License
 

--- a/QUALITY.md
+++ b/QUALITY.md
@@ -1,0 +1,111 @@
+# Quality Cycles
+
+## Cycle 1 — 2026-07-12
+
+**Scope**: comments, documentation, duplication. Architecture and general hygiene were out of
+scope. 12 review agents over `src/main`, 18 test suites, `benchmarks/`, `specs/`, and 7 docs.
+
+The hunt was scoped to prose. It found two live bugs, a public API that did not compile, and a
+model that was checking a stronger guard than the code implements.
+
+### Two live defects, both fixed (PR #69)
+
+**A lost wakeup when a transaction parks on a map key that does not exist.** Reading an absent
+key recorded no log entry, and `anyReadChangedSinceRead` — the *second* of H1's two park guards
+— folds over the log. The guard was structurally blind on that path. Found not by a test but by
+an agent asking why one of five copies of the same key-resolution code looked different from
+the other four.
+
+It is **not reachable by any behavioural test**, so it was confirmed by TLC —
+`SchedulerAbsentKey.cfg` is `SchedulerRetry.cfg` with the parker's read unlogged and nothing
+else changed, and it deadlocks where `SchedulerRetry` verifies clean. Two things are worth
+keeping from it:
+
+- **The model had the same blind spot.** `Scheduler.tla` computed park-time staleness over the
+  transaction's *actual* footprint; the code computes it over the *log*. For an absent-key read
+  those differ, so the spec had been checking a **stronger guard than the code implements**.
+  That is why neither TLC nor the soak caught it. `ActualFP` and `LoggedFP` are now distinct.
+- **The premise was written down three times and never joined up** — `TxnLogContext`,
+  `SerializabilityOracleSpec`, and the CHANGELOG each state "reading an absent map key records
+  no entry", every one of them as justification for something else.
+
+**An unbounded retry loop, re-publishing on every lap, for any transaction yielding `null`.**
+`Option(...)` mapped a null result to `None`, and `None` already meant "refine and re-run". A
+`TxnVar[F, String]` holding `null`, read straight back out, hung forever.
+
+### The dominant prose finding
+
+**The fixes landed; the prose did not.** Around 25 sites still described a pre-fix world,
+including four `.cfg` headers reading "EXPECTED RED" while CI asserted clean, a comment
+describing a "shadow log" half of the H3 fix that was *deliberately rejected and never built*,
+and `specs/README.md` — the self-declared source of truth — opening with "Two confirmed
+defects, both pinned red" about two defects it later confirmed were fixed.
+
+Neither guard could catch this. `check_expected.sh` compares TLC's *output* to CI's assertion,
+so a `.cfg`'s header prose is invisible to it. `verify_anchors.sh` checks that an anchor
+**exists**, not that it is **true** — which is also how `NoLostWakeup` came to be listed under
+a column headed "TLA+ Invariant" despite existing in no `.tla` file.
+
+`docs/plans/formal-specs.md` had become a *second* verdict source, and both doc-vs-doc
+contradictions came from exactly that. It is archived. `specs/README.md` is the only one now,
+and `check_expected.sh` no longer tells you to go update the other.
+
+### The user-facing surface was broken
+
+Every code example in the README failed to compile (`import bengal.stm.STM`; the root package
+is `ai.entrolution`). Every test sits *inside* `package ai.entrolution`, where the relative
+import resolves — so the whole suite stayed green while nothing a user copied would build.
+`src/test/scala/usercode/` now compiles the public API from a user's vantage point.
+
+`waitFor`'s wake-up contract was documented nowhere: the predicate is evaluated eagerly at
+construction, and what wakes a parked transaction is its **read set**. Hoist the read out of the
+transaction and it parks forever. `fromF`/`delay` effects run **twice** per attempt, which
+`fromF` — the sharpest edge in the API — did not say at all.
+
+And the README's flagship footprint-hazard example **did not trigger the hazard**: `set`'s value
+argument is by-name and suspended, and the analyser forces only the *key* thunk. The `.getOrElse`
+fix printed beneath it was a no-op.
+
+### Tests that could not fail
+
+`TxnLockOrderingSpec` is named for lock ordering and **structurally cannot deadlock** — its
+transactions have incompatible footprints, so the scheduler serializes them and the lock code is
+never reached concurrently. It could never have caught H2, and its assertion passed under a lost
+update (proven: disable the compatibility relation and it observes exactly `(3,3)`, sum 6,
+against an assertion of `> 3`).
+
+`StaticAnalysisFallbackSpec`'s three arms had all converged on asserting the same thing, so
+nothing checked that the H3 shape still *reaches* the fallback — while three files depend on it.
+It now has a probe that goes red both when the fix is reverted **and** when the shape stops
+throwing.
+
+### NC-8: a negative control that does not fire
+
+Deleting the commit-time dirty check outright (`IsDirty(t) == FALSE`) leaves **all seven**
+commit configs verifying clean. Spec A does not check it. The refinement action is now split on
+disjoint guards so that this is visible at all — previously both triggers shared one action and
+`"DirtyRestart fires"` was `CommitDirty`'s non-vacuity evidence while proving nothing.
+
+There is a reading in which this is correct rather than a gap (H6's coverage check aborts a
+divergent transaction *before* the publish that would have made a peer dirty). The model cannot
+distinguish that from a catalogue too small to isolate it. Recorded as an open gap; the check
+stays in the code.
+
+### What the review process itself got wrong
+
+Worth recording, because the corrections came from adversarial review rather than from care:
+
+- A TLC state count taken from a **parallel** run was labelled `-workers 1` and propagated into
+  the source of truth. Parallel counts do not reproduce (9,201 then 8,843 on consecutive runs).
+- `CI=true` **does not enable fatal warnings** in this build — sbt-typelevel keys them off
+  `GITHUB_ACTIONS`. Every local "CI gate" run this cycle compiled with warnings non-fatal and
+  reported success. The gate was theatre.
+- Three code comments asserting *why* something was true (`@nowarn`'s purpose, the `hasDownstream`
+  branch's reason, the `tally >= -2` allowance) were wrong, and each was corrected by someone
+  removing the thing and measuring what actually happened.
+
+### Counts
+
+- 143 → **207** tests, none ignored (the two `TxnLogDirtySpec` park/wake tests, disabled as
+  "flaky" in v0.12.0, were reporting H1; they are back and pass 80/80 under load).
+- **12** CI-pinned TLC expectations: ten expected-clean, two pinned-red.

--- a/specs/README.md
+++ b/specs/README.md
@@ -101,106 +101,63 @@ rot on every edit and `verify_anchors.sh` cannot guard them.
 
 ## Running the Model Checker
 
-From the repository root. Every result below is asserted by
-`specs/check_expected.sh`, which encodes whether a run is expected clean or
-expected to reproduce a **pinned counterexample** (an EXPECTED-RED verdict):
+From the repository root:
 
 ```bash
-# Footprint lemmas — expected clean, 38.7s (the coverage lemma quantifies over
-# ordered TRIPLES; it dominates the run)
-./specs/check_expected.sh specs/common/FootprintLemmas.cfg \
-    specs/common/FootprintLemmas.tla NONE
-
-# Scheduler safety — expected CLEAN since the H4 fix (exhaustive,
-# deadlock detection on), 36.1s
-./specs/check_expected.sh specs/scheduler/Scheduler.cfg \
-    specs/scheduler/Scheduler.tla NONE
-
-# Retry / park / wake — expected CLEAN since the H1 fix. A lost wakeup shows
-# up here as a deadlock, so no invariant names it. 1.7s
-./specs/check_expected.sh specs/scheduler/SchedulerRetry.cfg \
-    specs/scheduler/Scheduler.tla NONE
-
-# The park guard's negative control — expected RED (pinned DEADLOCK). This is
-# SchedulerRetry with ONE change: the parker's read records no log entry, which
-# is what a `waitFor` on an ABSENT MAP KEY did before the fix. ~30s
-./specs/check_expected.sh specs/scheduler/SchedulerAbsentKey.cfg \
-    specs/scheduler/Scheduler.tla DEADLOCK
-
-# Robustness config — expected RED (pinned CompletionAtMostOnce);
-# ALLOW_DEADLOCK suppresses deadlock detection for aborted-zombie states
-./specs/check_expected.sh specs/scheduler/SchedulerAborts.cfg \
-    specs/scheduler/Scheduler.tla CompletionAtMostOnce ALLOW_DEADLOCK
-
-# --- Commit protocol (Spec A) ---
-
-# H2 — lock ordering across two maps, plus the lock-aliasing (`dbl`) case.
-# EXPECTED CLEAN since the H2 fix.
-./specs/check_expected.sh specs/commit/CommitH2.cfg \
-    specs/commit/CommitProtocol.tla NONE
-
-# H3 — the static-analysis fallback. EXPECTED CLEAN since the H3 fix, in all
-# three directions the defect had:
-#   CommitH3        the EMPTY-footprint extreme (case _ => IdFootprint.empty)
-#   CommitH3Partial the PARTIAL footprint ordinary code actually produces
-#                   (StaticAnalysisShortCircuitException)
-#   CommitH3Writer  an under-declared WRITER breaking a correctly-declared
-#                   peer's reads (it has no reads of its own at all)
-./specs/check_expected.sh specs/commit/CommitH3.cfg \
-    specs/commit/CommitProtocol.tla NONE
-./specs/check_expected.sh specs/commit/CommitH3Partial.cfg \
-    specs/commit/CommitProtocol.tla NONE
-./specs/check_expected.sh specs/commit/CommitH3Writer.cfg \
-    specs/commit/CommitProtocol.tla NONE
-
-# H6 — data-dependent footprint divergence. The declared footprint names the
-# WRONG ids because the walker computed them from a value that changed before
-# the transaction was scheduled. EXPECTED CLEAN since the H6 fix.
-./specs/check_expected.sh specs/commit/CommitH6.cfg \
-    specs/commit/CommitProtocol.tla NONE
-
-# The dirty-refinement path. EXPECTED CLEAN.
-./specs/check_expected.sh specs/commit/CommitDirty.cfg \
-    specs/commit/CommitProtocol.tla NONE
-
-# Accurate footprints, including the H5 idiom. EXPECTED CLEAN — the H5 fix,
-# confirmed from the commit-protocol side. The largest Spec A config, at 3.4s.
-./specs/check_expected.sh specs/commit/CommitAccurate.cfg \
-    specs/commit/CommitProtocol.tla NONE
-
-# Raw TLC invocation (traces print to stdout; TTrace files are gitignored):
-java -XX:+UseParallelGC -cp specs/tla2tools.jar tlc2.TLC \
-    -config specs/scheduler/Scheduler.cfg specs/scheduler/Scheduler.tla \
-    -workers auto
+./specs/expectations.sh --list          # what is registered, and validate it. No TLC.
+./specs/expectations.sh                 # model-check every push-gated expectation
+./specs/expectations.sh --all           # ...including the dispatch-gated ones
+./specs/expectations.sh --measure       # regenerate specs/measured.tsv
+./specs/expectations.sh --check-readme  # the table below vs the measurement
+./specs/verify_anchors.sh               # every // SPEC: anchor maps to a row here
 ```
 
-Deadlock detection is ENABLED for organic Scheduler runs (no `-deadlock`
-flag): legitimate terminals — every completion signal fired — stutter via
-the explicit `Terminating` action, so any reported deadlock is a real
-protocol deadlock. That is what makes `DEADLOCK` a usable pinned expectation
-in its own right, and it is how `SchedulerAbsentKey` is pinned. The
-failure-injection config passes `ALLOW_DEADLOCK` (the script's 4th argument
-adds `-deadlock`) because aborted zombies legitimately strand their
-dependents.
+**Each config declares its own expectation, and that is the only place it is
+stated.** The directives live at the top of every `.cfg`:
 
-CI (`.github/workflows/specs.yml`) encodes **twelve** model-checking
-expectations: **ten expected clean** (the lemma check, `Scheduler`,
-`SchedulerRetry`, and all **seven** commit-protocol configs) and **two pinned
-red** — `SchedulerAbsentKey` (pinned `DEADLOCK`, the park guard's negative
-control) and `SchedulerAborts` (pinned `CompletionAtMostOnce`). Eleven of them
-run with `verify_anchors.sh` on every change to `specs/**` or the in-scope
-runtime sources; `SchedulerAborts` alone is `workflow_dispatch`-gated. That
-always-on set costs about 115 s of TLC, of which the lemma check and the two
-large Scheduler runs are nearly all — every config's measured time is in the
-state-space table below.
+```
+\* @spec    specs/scheduler/Scheduler.tla
+\* @expect  NONE | DEADLOCK | <InvariantName>
+\* @flags   ALLOW_DEADLOCK        (optional)
+\* @run     push | dispatch       (optional; default push)
+\* @measure no                    (optional; opt out of state-space measurement)
+```
 
-Expectations bind in **both** directions. A clean spec going red means a
-protocol regression (or rolling-TLC drift — the `v1.8.0` tag is a nightly;
-investigate which). A pinned counterexample that stops reproducing means the
-modelled defect changed shape — for `SchedulerAbsentKey` that would mean the
-model stopped modelling the unlogged read, or the park protocol was
-restructured; either needs a human before the pin is touched. Fix and spec
-move together (this verdict table, the cfg, and the plan's hypothesis rows).
+CI globs the directory and derives its steps from those. That arrangement is
+deliberate, and it is a response to how this suite actually failed.
+
+The expectation used to live in **two** places — prose in the cfg header
+("EXPECTED RED: `CommitSnapshotValid`") and an argument in
+`.github/workflows/specs.yml` — with nothing tying them together. They drifted.
+**Four cfg headers read EXPECTED RED for months while CI asserted `NONE`**, and
+`check_expected.sh` could not see it, because all it ever does is compare TLC's
+*output* to the argument it was handed. A cfg could also ship with no stated
+verdict at all (`CommitH6` did), or exist and be run by nothing.
+
+So three failure modes are now impossible rather than merely discouraged:
+
+| Failure | Why it cannot happen |
+|---|---|
+| a config with no stated verdict | `--list` fails |
+| a config that no CI step runs | CI globs `specs/*/*.cfg`; there is no list to forget |
+| a header that disagrees with CI | there is only **one** declaration to disagree with |
+
+`--list` also **rejects a config that states a verdict in prose**. Explain *why*
+a config verifies as it does at any length you like; just do not restate *what*
+it verifies as, because a restatement is a thing that can rot.
+
+**State counts are regenerated, not remembered.** `specs/measured.tsv` is
+produced by an actual run and committed; CI re-measures and fails on a diff, then
+checks the table below against it. Nothing else would catch that class of rot —
+the Scheduler config advertised "~24k distinct states" against a real **846,000**,
+and the lemma check was documented at "~1s" against a real **39s**. Both sat there
+for months, and both were eventually chased out of one file and left in another.
+
+Only exhaustive (`@expect NONE`) configs are measured. A run that **halts on a
+violation** explores a scheduling-dependent prefix, so its counts do not
+reproduce — consecutive `-workers auto` runs of `SchedulerAbsentKey` gave 9,201
+and 8,843. Pinning a number like that yields a guard that fails at random, which
+is worse than no guard.
 
 ## Verdict Table (source of truth)
 

--- a/specs/check_expected.sh
+++ b/specs/check_expected.sh
@@ -71,8 +71,10 @@ if [[ "$EXPECTED" == "DEADLOCK" ]]; then
     exit 0
   fi
   echo "UNEXPECTED: $TLA ($CFG) did not reproduce the pinned deadlock (exit $TLC_EXIT)." >&2
-  echo "If the protocol changed, update specs/README.md's verdict table and this CI" >&2
-  echo "expectation together — those two are the only places a verdict is recorded." >&2
+  echo "If the protocol changed, update the config's '\\* @expect' directive and" >&2
+  echo "specs/README.md's verdict table. @expect is the ONLY place the verdict is" >&2
+  echo "declared -- do NOT restate it in the config's prose. specs/expectations.sh" >&2
+  echo "--list rejects that: a restatement is a thing that can rot, and did." >&2
   tail -40 "$OUT" >&2
   exit 1
 fi
@@ -83,7 +85,9 @@ if grep -q "Invariant $EXPECTED is violated" "$OUT"; then
 fi
 
 echo "UNEXPECTED: $TLA ($CFG) did not reproduce the pinned $EXPECTED violation (exit $TLC_EXIT)." >&2
-echo "If the protocol changed, update specs/README.md's verdict table and this CI" >&2
-echo "expectation together — those two are the only places a verdict is recorded." >&2
+echo "If the protocol changed, update the config's '\\* @expect' directive and" >&2
+echo "specs/README.md's verdict table. @expect is the ONLY place the verdict is" >&2
+echo "declared -- do NOT restate it in the config's prose. specs/expectations.sh" >&2
+echo "--list rejects that: a restatement is a thing that can rot, and did." >&2
 tail -40 "$OUT" >&2
 exit 1

--- a/specs/commit/CommitAccurate.cfg
+++ b/specs/commit/CommitAccurate.cfg
@@ -1,3 +1,6 @@
+\* @spec    specs/commit/CommitProtocol.tla
+\* @expect  NONE
+\*
 \* Spec A — the ACCURATE-mode verification: no under-declaration anywhere, so
 \* Contract C is in full force and the footprint relation is the whole defence.
 \*
@@ -25,7 +28,7 @@
 \*              pin), and it is incompatible with h3b, so its read is
 \*              protected too.
 \*
-\* EXPECTED CLEAN, with deadlock detection ON (legitimate terminals stutter via
+\* Verifies with deadlock detection ON (legitimate terminals stutter via
 \* Terminating). Note what this does NOT say: H2 is reachable on accurate
 \* footprints too — it just needs two MAPS, which this config does not give the
 \* transactions in a conflicting order. CommitH2.cfg is where that lives.

--- a/specs/commit/CommitDirty.cfg
+++ b/specs/commit/CommitDirty.cfg
@@ -1,5 +1,8 @@
+\* @spec    specs/commit/CommitProtocol.tla
+\* @expect  NONE
+\*
 \* Spec A — the refinement path (release, re-declare from the log, re-run), as it
-\* stands after the H3 and H6 fixes. EXPECTED CLEAN.
+\* stands after the H3 and H6 fixes.
 \*
 \* This config had to be REWRITTEN when the H3 fix landed, and why is the most
 \* important thing on this page.
@@ -41,7 +44,7 @@
 \* with wwa's honestly, so Contract C serializes the pair from then on. There is
 \* no "loser of a race" here; the divergence is caught by self-inspection.
 \*
-\* EXPECTED CLEAN, and the refinement path is reachable and fires. Be precise
+\* The refinement path is reachable and fires. Be precise
 \* about which trigger fires it, because that question used to be unanswerable.
 \*
 \* Since the H6 fix there are TWO ways to reach a refinement, and they used to

--- a/specs/commit/CommitH2.cfg
+++ b/specs/commit/CommitH2.cfg
@@ -1,4 +1,7 @@
-\* Spec A — H2: lock ordering across two maps. EXPECTED CLEAN SINCE THE H2 FIX.
+\* @spec    specs/commit/CommitProtocol.tla
+\* @expect  NONE
+\*
+\* Spec A — H2: lock ordering across two maps. Verifies since the H2 fix.
 \*
 \* Scenario:
 \*   h2a, h2b — each inserts a fresh key into BOTH maps. Their declared
@@ -36,7 +39,7 @@
 \*              it dedupes on (the (owner id, Semaphore) pair rather than the
 \*              bare Semaphore), so it needs its own pin.
 \*
-\* EXPECTED CLEAN, exhaustive, with deadlock detection ON. Two negative controls
+\* Exhaustive, with deadlock detection ON. Two negative controls
 \* keep this honest (both in specs/README.md): NC-1 reverts the sort key to the
 \* log key and NoWaitsForCycle goes red; NC-5 removes the `.distinct` and `dbl`
 \* self-deadlocks. Both still reproduce their counterexamples, which is what

--- a/specs/commit/CommitH3.cfg
+++ b/specs/commit/CommitH3.cfg
@@ -1,5 +1,8 @@
+\* @spec    specs/commit/CommitProtocol.tla
+\* @expect  NONE
+\*
 \* Spec A — H3: write skew when the static-analysis fallback under-declares.
-\* EXPECTED CLEAN SINCE THE H3 FIX.
+\* Verifies since the H3 fix.
 \*
 \* Scenario: h3a does `r x, w y`; h3b does `r y, w x`. Both are in
 \* UnderDeclared — modelling TxnRuntime.commit's handleErrorWith, which falls

--- a/specs/commit/CommitH3Partial.cfg
+++ b/specs/commit/CommitH3Partial.cfg
@@ -1,5 +1,8 @@
+\* @spec    specs/commit/CommitProtocol.tla
+\* @expect  NONE
+\*
 \* Spec A — H3 AS ORDINARY CODE ACTUALLY REACHES IT.
-\* EXPECTED CLEAN SINCE THE H3 FIX.
+\* Verifies since the H3 fix.
 \*
 \* CommitH3.cfg models the EXTREME point of the under-approximation class: an
 \* EMPTY declared footprint, from TxnRuntime.commit's `case _ =>
@@ -45,7 +48,7 @@
 \* either — Contract C separated them long before withLock. The skew cannot
 \* happen, and CommitSnapshotValid HOLDS.
 \*
-\* EXPECTED CLEAN — the same verdict as CommitH3.cfg, reached by the same
+\* Reaches the same verdict as CommitH3.cfg, by the same
 \* mechanism, now on the footprint the real code actually produces rather than
 \* on the worst-case idealisation. That the two agree is the point of running
 \* both: the fix keys on the flag, so it cannot care how much of the footprint

--- a/specs/commit/CommitH3Writer.cfg
+++ b/specs/commit/CommitH3Writer.cfg
@@ -1,5 +1,8 @@
+\* @spec    specs/commit/CommitProtocol.tla
+\* @expect  NONE
+\*
 \* Spec A — H3, second direction: an UNDER-DECLARED WRITE against an
-\* ACCURATELY-DECLARED READ. EXPECTED CLEAN SINCE THE H3 FIX.
+\* ACCURATELY-DECLARED READ. Verifies since the H3 fix.
 \*
 \* Scenario: wwa writes x and is under-declared. h3a reads x and writes y, and
 \* declares both accurately.

--- a/specs/commit/CommitH6.cfg
+++ b/specs/commit/CommitH6.cfg
@@ -1,5 +1,8 @@
+\* @spec    specs/commit/CommitProtocol.tla
+\* @expect  NONE
+\*
 \* Spec A — H6: DATA-DEPENDENT FOOTPRINT DIVERGENCE.
-\* EXPECTED CLEAN SINCE THE H6 FIX (the commit-time coverage check).
+\* Verifies since the H6 fix (the commit-time coverage check).
 \*
 \* The hole the H3 fix could not reach — it was the last one standing, and it is
 \* the reason the commit protocol now checks its own footprint.

--- a/specs/common/FootprintLemmas.cfg
+++ b/specs/common/FootprintLemmas.cfg
@@ -1,3 +1,11 @@
+\* @spec    specs/common/FootprintLemmas.tla
+\* @expect  NONE
+\* @measure no
+\*
+\* No state graph to measure: all the checking happens in named ASSUMEs at TLC
+\* startup and the behaviour spec is a single-state stutter, so its "state count"
+\* is 1 and means nothing. Pinning it would be pinning noise.
+\*
 \* Footprint relation lemmas — exhaustive over the 4-id universe: 512 footprints
 \* (2^4 reads x 2^4 updates x 2 for the H3 under-approximation flag).
 \* All checking happens in the named ASSUMEs at TLC startup; the behaviour spec

--- a/specs/expectations.sh
+++ b/specs/expectations.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# The expectation registry. Every .cfg under specs/ declares what TLC must
+# report, and this is the only place that list exists.
+#
+# WHY THIS EXISTS. The expectation used to live in TWO places: prose in the
+# cfg header ("EXPECTED RED: CommitSnapshotValid") and an argument in
+# .github/workflows/specs.yml. Nothing tied them together, and they drifted --
+# four cfg headers said EXPECTED RED for months while CI asserted NONE, and
+# check_expected.sh could not see it because it only ever compares TLC's OUTPUT
+# to the argument CI passed it. A cfg could also ship with no stated expectation
+# at all (CommitH6 did), or exist and be run by nothing.
+#
+# So the cfg is now the source of truth and CI derives from it. Three failure
+# modes become impossible by construction rather than merely discouraged:
+#
+#   * a cfg with no expectation      -> this script fails
+#   * a cfg no CI step runs          -> CI globs the directory; there is no list to forget
+#   * a header that disagrees with CI -> there is only one declaration to disagree with
+#
+# DIRECTIVES. Each cfg carries a block of these, in TLA+ comment syntax:
+#
+#   \* @spec    specs/scheduler/Scheduler.tla    (required)
+#   \* @expect  NONE | DEADLOCK | <InvariantName> (required; passed verbatim to check_expected.sh)
+#   \* @flags   ALLOW_DEADLOCK                   (optional)
+#   \* @run     push | dispatch                  (optional; default push)
+#
+# USAGE
+#   ./specs/expectations.sh --list      parse and validate; print the table; run no TLC
+#   ./specs/expectations.sh             run every push-gated expectation
+#   ./specs/expectations.sh --all       also run the dispatch-gated ones
+set -uo pipefail
+
+cd "$(dirname "$0")/.." || exit 1
+
+MODE="${1:-run}"
+
+directive() {  # directive <file> <name>
+  sed -nE "s|^\\\\\* *@$2 +(.*[^ ]) *$|\1|p" "$1" | head -1
+}
+
+fail=0
+rows=()
+
+shopt -s nullglob
+cfgs=(specs/*/*.cfg)
+shopt -u nullglob
+
+if [[ ${#cfgs[@]} -eq 0 ]]; then
+  echo "ERROR: no .cfg files found under specs/" >&2
+  exit 1
+fi
+
+for cfg in "${cfgs[@]}"; do
+  spec=$(directive "$cfg" spec)
+  expect=$(directive "$cfg" expect)
+  flags=$(directive "$cfg" flags)
+  run=$(directive "$cfg" run)
+  run="${run:-push}"
+
+  if [[ -z "$expect" ]]; then
+    echo "ERROR: $cfg declares no '\\* @expect' directive." >&2
+    echo "       Every config must state what TLC is expected to report." >&2
+    fail=1
+    continue
+  fi
+  if [[ -z "$spec" ]]; then
+    echo "ERROR: $cfg declares no '\\* @spec' directive (which .tla to check it against)." >&2
+    fail=1
+    continue
+  fi
+  if [[ ! -f "$spec" ]]; then
+    echo "ERROR: $cfg names a spec that does not exist: $spec" >&2
+    fail=1
+    continue
+  fi
+  if [[ "$run" != "push" && "$run" != "dispatch" ]]; then
+    echo "ERROR: $cfg has '\\* @run $run'; expected 'push' or 'dispatch'." >&2
+    fail=1
+    continue
+  fi
+
+  # NO SECOND DECLARATION. @expect is the only place a verdict may be stated.
+  # The prose that used to carry one drifted for months -- four headers read
+  # "EXPECTED RED" while CI asserted NONE -- because nothing could compare a
+  # sentence to an argument. Rather than try to reconcile two declarations, we
+  # forbid the second. Explain the reasoning in prose all you like; just do not
+  # restate the verdict there, because a restatement is a thing that can rot.
+  if grep -qiE 'EXPECTED +(RED|CLEAN)' "$cfg"; then
+    echo "ERROR: $cfg states a verdict in prose ('EXPECTED RED/CLEAN')." >&2
+    echo "       The verdict belongs in '\\* @expect' and nowhere else -- a second" >&2
+    echo "       declaration is the thing that drifted last time. Reword the prose to" >&2
+    echo "       explain WHY the config verifies as it does, and let @expect say WHAT." >&2
+    fail=1
+    continue
+  fi
+
+  rows+=("$cfg|$spec|$expect|$flags|$run")
+done
+
+if [[ $fail -ne 0 ]]; then
+  exit 1
+fi
+
+if [[ "$MODE" == "--list" ]]; then
+  printf "%-42s %-38s %-22s %-16s %s\n" CONFIG SPEC EXPECT FLAGS RUN
+  for row in "${rows[@]}"; do
+    IFS='|' read -r cfg spec expect flags run <<<"$row"
+    printf "%-42s %-38s %-22s %-16s %s\n" "$cfg" "$spec" "$expect" "${flags:--}" "$run"
+  done
+  echo
+  echo "${#rows[@]} expectations, all declared."
+  exit 0
+fi
+
+# --measure regenerates specs/measured.tsv, which CI then diffs. This is the
+# only thing that catches a stale STATE COUNT, and nothing did before: the
+# Scheduler config's header claimed "~24k distinct states" while the truth was
+# 846k, and the lemma check was documented at "~1s" against a real 39s. Prose
+# discipline will not catch that class of rot; a regenerated file will.
+#
+# ONLY @expect NONE configs are measured, and the reason is the same mistake in
+# miniature. An exhaustive run explores the whole reachable state space, so its
+# counts are a property of the spec and reproduce exactly. A run that HALTS on a
+# violation explores a scheduling-dependent prefix, and its counts do not:
+# consecutive -workers auto runs of SchedulerAbsentKey gave 9,201 and 8,843.
+# Pinning a number like that would produce a guard that fails at random, which
+# is worse than no guard.
+if [[ "$MODE" == "--measure" ]]; then
+  out=specs/measured.tsv
+  {
+    echo "# Measured state spaces. GENERATED -- do not hand-edit."
+    echo "# Regenerate with: ./specs/expectations.sh --measure"
+    echo "#"
+    echo "# Only exhaustive (@expect NONE) configs appear. A run that halts on a"
+    echo "# violation explores a scheduling-dependent prefix and its counts do not"
+    echo "# reproduce, so pinning them would produce a guard that fails at random."
+    printf "#\n# %-40s\t%s\t%s\t%s\n" config generated distinct depth
+  } >"$out"
+
+  for row in "${rows[@]}"; do
+    IFS='|' read -r cfg spec expect flags run <<<"$row"
+    [[ "$expect" == "NONE" ]] || continue
+    [[ "$(directive "$cfg" measure)" == "no" ]] && continue
+    echo "measuring $cfg ..." >&2
+    res=$(java -XX:+UseParallelGC -cp specs/tla2tools.jar tlc2.TLC \
+            -config "$cfg" "$spec" -workers auto 2>&1)
+    gen=$(sed -nE 's/^([0-9]+) states generated, ([0-9]+) distinct.*/\1/p' <<<"$res" | tail -1)
+    dis=$(sed -nE 's/^([0-9]+) states generated, ([0-9]+) distinct.*/\2/p' <<<"$res" | tail -1)
+    dep=$(sed -nE 's/.*depth of the complete state graph search is ([0-9]+).*/\1/p' <<<"$res" | tail -1)
+    if [[ -z "$gen" || -z "$dis" ]]; then
+      echo "ERROR: could not parse a state count out of $cfg." >&2
+      exit 1
+    fi
+    printf "%-42s\t%s\t%s\t%s\n" "$cfg" "$gen" "$dis" "${dep:--}" >>"$out"
+  done
+  echo "wrote $out" >&2
+  exit 0
+fi
+
+# specs/README.md publishes these counts in its state-space table, and a guard
+# that only checked measured.tsv would let the TABLE rot while the file stayed
+# current -- which is how the 24k-vs-846k figure survived: someone chased it out
+# of one file and left it in another. So the table is checked against the
+# measurement, not against anyone's memory.
+if [[ "$MODE" == "--check-readme" ]]; then
+  if [[ ! -f specs/measured.tsv ]]; then
+    echo "ERROR: specs/measured.tsv is missing. Run: ./specs/expectations.sh --measure" >&2
+    exit 1
+  fi
+  bad=0
+  while IFS=$'\t' read -r cfg gen dis dep; do
+    [[ "$cfg" =~ ^# ]] && continue
+    [[ -z "${cfg// }" ]] && continue
+    cfg="${cfg// }"
+    name=$(basename "$cfg" .cfg)
+    row=$(grep -E "^\| \`$name\` \|" specs/README.md | head -1)
+    if [[ -z "$row" ]]; then
+      echo "ERROR: specs/README.md has no state-space row for \`$name\`." >&2
+      bad=1
+      continue
+    fi
+    # "6,082 / 2,100" -> 6082 2100
+    got=$(sed -E 's/.*\| *([0-9,]+) *\/ *([0-9,]+) *\|.*/\1 \2/' <<<"$row" | tr -d ',')
+    rgen=$(cut -d' ' -f1 <<<"$got")
+    rdis=$(cut -d' ' -f2 <<<"$got")
+    if [[ "$rgen" != "$gen" || "$rdis" != "$dis" ]]; then
+      echo "ERROR: specs/README.md is stale for \`$name\`:" >&2
+      echo "         table says  $rgen / $rdis" >&2
+      echo "         TLC reports $gen / $dis" >&2
+      bad=1
+    fi
+  done <specs/measured.tsv
+  if [[ $bad -ne 0 ]]; then
+    echo >&2
+    echo "Re-measure and update the table:  ./specs/expectations.sh --measure" >&2
+    exit 1
+  fi
+  echo "specs/README.md state-space table agrees with specs/measured.tsv."
+  exit 0
+fi
+
+status=0
+for row in "${rows[@]}"; do
+  IFS='|' read -r cfg spec expect flags run <<<"$row"
+  if [[ "$run" == "dispatch" && "$MODE" != "--all" ]]; then
+    echo "SKIP: $cfg (dispatch-gated; use --all)"
+    continue
+  fi
+  # shellcheck disable=SC2086
+  ./specs/check_expected.sh "$cfg" "$spec" "$expect" $flags || status=1
+done
+
+exit $status

--- a/specs/measured.tsv
+++ b/specs/measured.tsv
@@ -1,0 +1,17 @@
+# Measured state spaces. GENERATED -- do not hand-edit.
+# Regenerate with: ./specs/expectations.sh --measure
+#
+# Only exhaustive (@expect NONE) configs appear. A run that halts on a
+# violation explores a scheduling-dependent prefix and its counts do not
+# reproduce, so pinning them would produce a guard that fails at random.
+#
+# config                                  	generated	distinct	depth
+specs/commit/CommitAccurate.cfg           	31368	11385	48
+specs/commit/CommitDirty.cfg              	187	121	27
+specs/commit/CommitH2.cfg                 	6082	2100	36
+specs/commit/CommitH3.cfg                 	51	45	21
+specs/commit/CommitH3Partial.cfg          	91	69	27
+specs/commit/CommitH3Writer.cfg           	45	41	20
+specs/commit/CommitH6.cfg                 	155	97	25
+specs/scheduler/Scheduler.cfg             	3775555	845687	85
+specs/scheduler/SchedulerRetry.cfg        	22483	7665	61

--- a/specs/scheduler/Scheduler.cfg
+++ b/specs/scheduler/Scheduler.cfg
@@ -1,6 +1,9 @@
+\* @spec    specs/scheduler/Scheduler.tla
+\* @expect  NONE
+\*
 \* Spec B verification config, ORGANIC protocol (no failure injection).
 \*
-\* EXPECTED CLEAN since the H4 fix (admission gate + fresh incarnations +
+\* Verifies since the H4 fix (admission gate + fresh incarnations +
 \* exactly-once cascades): all six safety invariants hold, the two-slot
 \* fiber bound drops nothing (NoDroppedSpawn), and TLC's deadlock detection
 \* runs ENABLED (no -deadlock flag — legitimate terminals stutter via

--- a/specs/scheduler/SchedulerAborts.cfg
+++ b/specs/scheduler/SchedulerAborts.cfg
@@ -1,3 +1,8 @@
+\* @spec    specs/scheduler/Scheduler.tla
+\* @expect  CompletionAtMostOnce
+\* @flags   ALLOW_DEADLOCK
+\* @run     dispatch
+\*
 \* Spec B robustness config: nondeterministic failure injection ON.
 \* Models "an exception lands anywhere handleErrorWith can see it"
 \* (execute's handleErrorWith and the submit wrapper in TxnRuntime.commit) — the model does not claim any

--- a/specs/scheduler/SchedulerAbsentKey.cfg
+++ b/specs/scheduler/SchedulerAbsentKey.cfg
@@ -1,3 +1,6 @@
+\* @spec    specs/scheduler/Scheduler.tla
+\* @expect  DEADLOCK
+\*
 \* Spec B — the park-time staleness check against an UNLOGGED read.
 \*
 \* tm is tr with EXACTLY ONE DIFFERENCE: its read of V1 records no log entry
@@ -15,7 +18,7 @@
 \* violation here is therefore caused by the missing log entry and nothing
 \* else: same protocol, same predicate, same write set, one absent entry.
 \*
-\* EXPECTED RED: deadlock. The H1 soundness argument needs both guards — the
+\* This one DEADLOCKS, and must keep doing so. The H1 soundness argument needs both guards — the
 \* scan catches conflictors still running, the staleness check catches those
 \* that already committed and left. With the second one structurally dead, a
 \* conflictor that completes inside the parker's [registerCompletion -> scan]

--- a/specs/scheduler/SchedulerRetry.cfg
+++ b/specs/scheduler/SchedulerRetry.cfg
@@ -1,10 +1,13 @@
+\* @spec    specs/scheduler/Scheduler.tla
+\* @expect  NONE
+\*
 \* Spec B retry/park/wake config (Phase 2): tr is a waitFor transaction
 \* (reads V1, retries until version[V1] >= 1, then writes V2); tw writes V1.
 \* Deadlock detection ON (no ALLOW_DEADLOCK): a parked-forever transaction
 \* is a dead-end state — H1's lost-wakeup manifests as a hard deadlock, not
 \* a fairness lasso.
 \*
-\* EXPECTED CLEAN since the H1 fix: submitTxnForRetry re-checks the read
+\* Verifies since the H1 fix: submitTxnForRetry re-checks the read
 \* set (hasChangedSinceRead) and scans activeTransactions for footprint
 \* conflicts inside the retry-semaphore region before parking — closing
 \* the lost-wakeup window. HISTORICAL (pre-fix): this config deadlocked at


### PR DESCRIPTION
Everything #70 fixed can rot again. Two guards, because two things rotted and neither had anything watching it.

## The expectation lived in two places

A config's expected verdict was stated **in prose in its header** (`EXPECTED RED: CommitSnapshotValid`) *and* as an **argument in `specs.yml`**. Nothing tied them together, so they drifted — **four headers read EXPECTED RED for months while CI asserted `NONE`**.

`check_expected.sh` could never have caught it: all it does is compare TLC's *output* to the argument it was handed, so a header is invisible to it. A config could equally ship with **no stated verdict at all** (`CommitH6` did), or **exist and be run by nothing**.

The config now declares its own expectation, and CI globs the directory:

```
\* @spec    specs/scheduler/Scheduler.tla
\* @expect  NONE | DEADLOCK | <InvariantName>
\* @flags   ALLOW_DEADLOCK        (optional)
\* @run     push | dispatch       (optional)
\* @measure no                    (optional)
```

Thirteen hand-written CI steps collapse to a glob. Three failure modes stop being *discouraged* and start being **impossible**:

| Failure | Why it can't happen now |
|---|---|
| a config with no stated verdict | `--list` fails |
| a config no CI step runs | CI globs the directory — there is no list to forget |
| a header that disagrees with CI | there is only **one** declaration to disagree with |

`--list` also **rejects a config that states a verdict in prose.** Explain *why* a config verifies as it does at any length; just don't restate *what* it verifies as — a restatement is a thing that can rot, and did. All ten configs carrying one have been reworded.

## State counts rotted silently, and prose discipline wouldn't have caught it

`Scheduler.cfg` advertised **"~24k distinct states"** against a real **845,687**. The lemma check was documented at **"~1s"** against a real **39s**. Both sat there for months — and the 24k figure was eventually chased out of one file and *left in another*.

`specs/measured.tsv` is now **generated** from an actual run and committed. CI re-measures, fails on the diff, then checks `specs/README.md`'s published table against it — because a guard that only watched the generated file would let the table rot beside it, which is precisely what happened last time.

**Only exhaustive (`@expect NONE`) configs are measured**, and that restriction is the same mistake in miniature. A run that *halts on a violation* explores a scheduling-dependent prefix and its counts don't reproduce: consecutive `-workers auto` runs of `SchedulerAbsentKey` gave **9,201 then 8,843**. Pinning that yields a guard that fails at random — worse than no guard.

That isn't hypothetical. During the last cycle a parallel count was mistaken for a reproducible one and propagated into the source of truth before it was caught.

## Both guards have negative controls

A guard that cannot fail is the thing this exercise keeps finding, so:

| Break | Result |
|---|---|
| remove an `@expect` | `--list` fails ✓ |
| restate a verdict in prose | `--list` fails ✓ |
| add a config nobody declared | `--list` fails ✓ |
| point `@spec` at a missing file | `--list` fails ✓ |
| make the README's count stale | `--check-readme` fails, naming both numbers ✓ |
| delete `measured.tsv` | `--check-readme` fails ✓ |

The README-staleness control was run against **the actual historical drift** (846k → 24k) and catches it.

## Test plan

- [x] All 12 expectations pass through the new registry (11 push + 1 dispatch-gated, correctly skipped)
- [x] `specs/measured.tsv` regenerated from a real run; all 9 measured configs match the published table
- [x] `verify_anchors.sh` — 17 invariants mapped, no orphans
- [x] Zero configs restate a verdict in prose
- [x] Six negative controls, all fire
- [x] No Scala touched